### PR TITLE
feat: implement Firebase App Distribution update checker and make pho…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -180,6 +180,7 @@ dependencies {
     implementation("com.google.firebase:firebase-auth")
     implementation("com.firebaseui:firebase-ui-auth:7.2.0")
     implementation("com.google.firebase:firebase-crashlytics-ktx")
+    implementation("com.google.firebase:firebase-appdistribution:16.0.0-beta16")
 
 
     // Google API Client & Sheets

--- a/app/src/main/java/com/raylabs/laundryhub/core/data/firebase/AppDistributionUpdateChecker.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/core/data/firebase/AppDistributionUpdateChecker.kt
@@ -1,0 +1,18 @@
+package com.raylabs.laundryhub.core.data.firebase
+
+import com.google.firebase.appdistribution.FirebaseAppDistribution
+import com.raylabs.laundryhub.core.domain.repository.UpdateCheckerRepository
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+class AppDistributionUpdateChecker(
+    private val fad: FirebaseAppDistribution
+) : UpdateCheckerRepository {
+
+    override suspend fun checkAndPromptIfNeeded(): Boolean =
+        suspendCancellableCoroutine { cont ->
+            fad.updateIfNewReleaseAvailable()
+                .addOnSuccessListener { cont.resume(true) }
+                .addOnFailureListener { cont.resume(false) }
+        }
+}

--- a/app/src/main/java/com/raylabs/laundryhub/core/di/FirebaseModule.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/core/di/FirebaseModule.kt
@@ -4,14 +4,18 @@ import android.content.Context
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.firebase.appdistribution.FirebaseAppDistribution
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.raylabs.laundryhub.BuildConfig
+import com.raylabs.laundryhub.core.data.firebase.AppDistributionUpdateChecker
 import com.raylabs.laundryhub.core.data.firebase.AuthRepositoryImpl
 import com.raylabs.laundryhub.core.data.firebase.FirebaseDataSource
 import com.raylabs.laundryhub.core.domain.repository.AuthRepository
+import com.raylabs.laundryhub.core.domain.repository.UpdateCheckerRepository
 import com.raylabs.laundryhub.core.domain.usecase.auth.CheckUserLoggedInUseCase
 import com.raylabs.laundryhub.core.domain.usecase.auth.SignInWithGoogleUseCase
+import com.raylabs.laundryhub.core.domain.usecase.update.CheckAppUpdateUseCase
 import com.raylabs.laundryhub.core.domain.usecase.user.UserUseCase
 import dagger.Module
 import dagger.Provides
@@ -81,4 +85,21 @@ object FirebaseModule {
     fun provideCrashlytics(): FirebaseCrashlytics {
         return FirebaseCrashlytics.getInstance()
     }
+
+
+    @Provides
+    @Singleton
+    fun provideFirebaseAppDistribution(): FirebaseAppDistribution =
+        FirebaseAppDistribution.getInstance()
+
+    @Provides
+    @Singleton
+    fun provideUpdateChecker(fad: FirebaseAppDistribution): UpdateCheckerRepository =
+        AppDistributionUpdateChecker(fad)
+
+    @Provides
+    @Singleton
+    fun provideCheckAppUpdateUseCase(
+        repo: UpdateCheckerRepository
+    ): CheckAppUpdateUseCase = CheckAppUpdateUseCase(repo)
 }

--- a/app/src/main/java/com/raylabs/laundryhub/core/domain/repository/UpdateCheckerRepository.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/core/domain/repository/UpdateCheckerRepository.kt
@@ -1,0 +1,5 @@
+package com.raylabs.laundryhub.core.domain.repository
+
+interface UpdateCheckerRepository {
+    suspend fun checkAndPromptIfNeeded(): Boolean
+}

--- a/app/src/main/java/com/raylabs/laundryhub/core/domain/usecase/update/CheckAppUpdateUseCase.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/core/domain/usecase/update/CheckAppUpdateUseCase.kt
@@ -1,0 +1,9 @@
+package com.raylabs.laundryhub.core.domain.usecase.update
+
+import com.raylabs.laundryhub.core.domain.repository.UpdateCheckerRepository
+
+class CheckAppUpdateUseCase(
+    private val checker: UpdateCheckerRepository
+) {
+    suspend operator fun invoke(): Boolean = checker.checkAndPromptIfNeeded()
+}

--- a/app/src/main/java/com/raylabs/laundryhub/ui/LaundryHubStarter.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/LaundryHubStarter.kt
@@ -268,16 +268,20 @@ fun ShowOrderBottomSheet(
                         homeViewModel.fetchSummary()
                         delay(500)
                         dismissSheet()
-                        val message = WhatsAppHelper.buildOrderMessage(
-                            customerName = uiState.name,
-                            packageName = uiState.selectedPackage?.name.orEmpty(),
-                            total = uiState.price,
-                            paymentStatus = uiState.paymentMethod
-                        )
+
                         val phone = uiState.phone
+                        if (phone.isNotEmpty()) {
+                            val message = WhatsAppHelper.buildOrderMessage(
+                                customerName = uiState.name,
+                                packageName = uiState.selectedPackage?.name.orEmpty(),
+                                total = uiState.price,
+                                paymentStatus = uiState.paymentMethod
+                            )
+                            WhatsAppHelper.sendWhatsApp(context, phone, message)
+                        }
+
                         orderViewModel.resetForm()
                         snackBarHostState.showSnackbar("Order #$id successfully submitted!, waiting for open wa...")
-                        WhatsAppHelper.sendWhatsApp(context, phone, message)
                     })
                 }
             }

--- a/app/src/main/java/com/raylabs/laundryhub/ui/MainActivity.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/MainActivity.kt
@@ -8,12 +8,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.lifecycleScope
+import com.raylabs.laundryhub.core.domain.usecase.update.CheckAppUpdateUseCase
 import com.raylabs.laundryhub.ui.onboarding.LoginViewModel
 import com.raylabs.laundryhub.ui.theme.LaundryHubTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject
+    lateinit var checkAppUpdate: CheckAppUpdateUseCase
+    private var hasCheckedUpdate = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -22,6 +30,16 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             LaundryHubTheme { AppRoot() }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (!hasCheckedUpdate) {
+            hasCheckedUpdate = true
+            lifecycleScope.launch {
+                checkAppUpdate()
+            }
         }
     }
 

--- a/app/src/main/java/com/raylabs/laundryhub/ui/common/util/WhatsAppHelper.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/common/util/WhatsAppHelper.kt
@@ -12,8 +12,7 @@ object WhatsAppHelper {
         customerName: String,
         packageName: String,
         total: String,
-        paymentStatus: String,
-        alamatLaundry: String = "[alamat laundry kamu]"
+        paymentStatus: String
     ): String {
         return """
             Halo, Kak $customerName!
@@ -26,8 +25,7 @@ object WhatsAppHelper {
             - Status Bayar: $paymentStatus
 
             Laundry siap diambil/akan dikabari jika selesai.
-            Alamat: $alamatLaundry
-
+            
             (Ray Labs Laundry)
         """.trimIndent()
     }

--- a/app/src/main/java/com/raylabs/laundryhub/ui/order/OrderBottomSheetScreen.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/order/OrderBottomSheetScreen.kt
@@ -1,5 +1,6 @@
 package com.raylabs.laundryhub.ui.order
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -146,7 +147,7 @@ fun OrderBottomSheet(
             modifier = Modifier.fillMaxWidth()
         )
         LaunchedEffect(state.isEditMode, state.phone) {
-            android.util.Log.d(
+            Log.d(
                 "OrderBottomSheet",
                 "PhoneField Rendered: isEditMode=${state.isEditMode}, phone=${state.phone}"
             )

--- a/app/src/main/java/com/raylabs/laundryhub/ui/order/state/OrderUiState.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/order/state/OrderUiState.kt
@@ -61,11 +61,11 @@ fun TransactionData.toUI(): OrderData {
         remark = remark,
         weight = weight,
         dueDate = dueDate
-    )}
+    )
+}
 
 val OrderUiState.isSubmitEnabled: Boolean
     get() = name.isNotBlank()
-            && phone.isNotBlank()
             && selectedPackage != null
             && price.isNotBlank()
             && paymentMethod.isNotBlank()

--- a/app/src/test/java/com/raylabs/laundryhub/core/domain/usecase/update/CheckAppUpdateUseCaseTest.kt
+++ b/app/src/test/java/com/raylabs/laundryhub/core/domain/usecase/update/CheckAppUpdateUseCaseTest.kt
@@ -1,0 +1,28 @@
+package com.raylabs.laundryhub.core.domain.usecase.update
+
+import com.raylabs.laundryhub.core.domain.repository.UpdateCheckerRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CheckAppUpdateUseCaseTest {
+
+    private class FakeChecker(private val result: Boolean) : UpdateCheckerRepository {
+        override suspend fun checkAndPromptIfNeeded(): Boolean = result
+    }
+
+    @Test
+    fun `should return true when checker reports update available`() = runTest {
+        val sut = CheckAppUpdateUseCase(FakeChecker(true))
+        val result = sut()
+        assertTrue(result)
+    }
+
+    @Test
+    fun `should return false when checker reports no update`() = runTest {
+        val sut = CheckAppUpdateUseCase(FakeChecker(false))
+        val result = sut()
+        assertFalse(result)
+    }
+}

--- a/app/src/test/java/com/raylabs/laundryhub/ui/common/util/WhatsAppHelperTest.kt
+++ b/app/src/test/java/com/raylabs/laundryhub/ui/common/util/WhatsAppHelperTest.kt
@@ -36,13 +36,11 @@ class WhatsAppHelperTest {
             packageName = "Reguler",
             total = "10.000",
             paymentStatus = "Cash",
-            alamatLaundry = "Jl. Pahlawan"
         )
         // Cek keyword/konten utama
         assert(result.contains("Halo, Kak Andi!"))
         assert(result.contains("- Paket: Reguler"))
         assert(result.contains("- Total: Rp 10.000"))
         assert(result.contains("- Status Bayar: Cash"))
-        assert(result.contains("Alamat: Jl. Pahlawan"))
     }
 }

--- a/app/src/test/java/com/raylabs/laundryhub/ui/order/state/OrderUiStateTest.kt
+++ b/app/src/test/java/com/raylabs/laundryhub/ui/order/state/OrderUiStateTest.kt
@@ -70,14 +70,13 @@ class OrderUiStateTest {
         val pkg = PackageItem(name = "Express", price = "10000", work = "6h")
         val valid = OrderUiState(
             name = "Sari",
-            phone = "0812",
             selectedPackage = pkg,
             price = "10000",
             paymentMethod = "Cash"
         )
         assertTrue(valid.isSubmitEnabled)
 
-        val invalid = valid.copy(phone = "")
+        val invalid = valid.copy(name = "")
         assertFalse(invalid.isSubmitEnabled)
     }
 


### PR DESCRIPTION
…ne optional in order

This commit introduces a feature to check for app updates using Firebase App Distribution. It also modifies the order submission process to make the phone number optional and removes the laundry address from the WhatsApp message.

Specific changes:
- Added `AppDistributionUpdateChecker` to check for new app releases.
- Implemented `CheckAppUpdateUseCase` and its unit tests.
- Integrated update check into `MainActivity`'s `onResume` lifecycle.
- Updated `OrderUiState` to allow order submission without a phone number.
- Modified `WhatsAppHelper` to remove the laundry address from the message.
- Added Firebase App Distribution dependency to `app/build.gradle`.
- Updated Dagger Hilt modules to provide necessary dependencies for the update checker.
- Adjusted tests for `WhatsAppHelper` and `OrderUiState` to reflect changes.
- Added logging in `OrderBottomSheetScreen`.