### PR TITLE
feat: Implement swipe-to-refresh and enhance Home screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,6 @@ plugins {
     id 'com.google.firebase.crashlytics'
     id 'jacoco'
     id 'com.github.kt3k.coveralls' version '2.12.0'
-    id 'io.gitlab.arturbosch.detekt' version '1.23.8'
 }
 
 def apikeyPropertiesFile = rootProject.file("config.properties")
@@ -23,11 +22,11 @@ versionProps.load(new FileInputStream(versionPropsFile))
 
 android {
     namespace 'com.raylabs.laundryhub'
-    compileSdk 35 //Need To Upgrade Gradle Plugin if we need to update the library
+    compileSdk 36
     defaultConfig {
         applicationId "com.raylabs.laundryhub"
         minSdkVersion 23
-        targetSdk 35 //Need To Upgrade Gradle Plugin if we need to update the library
+        targetSdk 36
         versionCode versionProps['VERSION_CODE'].toInteger()
         versionName versionProps['VERSION_NAME']
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
@@ -161,7 +160,7 @@ dependencies {
     implementation("com.google.firebase:firebase-auth")
     implementation("com.firebaseui:firebase-ui-auth:7.2.0")
     implementation("com.google.firebase:firebase-crashlytics-ktx")
-    implementation("com.google.firebase:firebase-appdistribution:16.0.0-beta16")
+    implementation("com.google.firebase:firebase-appdistribution-api:16.0.0-beta17")
 
 
     // Google API Client & Sheets

--- a/app/src/main/java/com/raylabs/laundryhub/ui/component/OrderStatusCard.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/component/OrderStatusCard.kt
@@ -14,9 +14,11 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.raylabs.laundryhub.R
 import com.raylabs.laundryhub.ui.common.dummy.home.DUMMY_UNPAID_ORDER_ITEM_EMY
 import com.raylabs.laundryhub.ui.home.state.UnpaidOrderItem
 
@@ -37,8 +39,8 @@ fun OrderStatusCard(
             modifier = Modifier
                 .padding(16.dp)
                 .fillMaxWidth()
-                .fillMaxHeight(), // pastikan konten memenuhi tinggi card
-            verticalArrangement = Arrangement.SpaceBetween // ratakan konten atas-bawah
+                .fillMaxHeight(),
+            verticalArrangement = Arrangement.SpaceBetween
         ) {
             // Header
             Text(
@@ -71,14 +73,14 @@ fun OrderStatusCard(
 
             // Due Date
             Text(
-                "Due Date",
+                stringResource(R.string.order_date),
                 fontWeight = FontWeight.Bold,
                 color = Color.White,
                 style = MaterialTheme.typography.subtitle2,
                 modifier = Modifier.padding(top = 12.dp)
             )
             Text(
-                item.dueDate,
+                item.orderDate,
                 color = Color.White,
                 fontWeight = FontWeight.Light,
                 style = MaterialTheme.typography.body2

--- a/app/src/main/java/com/raylabs/laundryhub/ui/home/state/HomeUiState.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/home/state/HomeUiState.kt
@@ -17,5 +17,6 @@ data class HomeUiState(
     val summary: SectionState<List<SummaryItem>> = SectionState(),
     val unpaidOrder: SectionState<List<UnpaidOrderItem>> = SectionState(),
     val detailOrder: SectionState<TransactionItem> = SectionState(),
-    val currentSortOption: SortOption = SortOption.ORDER_DATE_DESC // Default sort option
+    val currentSortOption: SortOption = SortOption.ORDER_DATE_DESC, // Default sort option
+    val isRefreshing: Boolean = false // Added for swipe-to-refresh
 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,5 @@
     <string name="order_date_newest">Order Date (Newest)</string>
     <string name="no_data">No Data</string>"
     <string name="hello">Hello,</string>
+    <string name="order_date">Order Date</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.13.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "com.google.gms:google-services:4.4.2"
+        classpath "com.google.gms:google-services:4.4.3"
         classpath "com.google.firebase:firebase-crashlytics-gradle:2.9.5"
 
 


### PR DESCRIPTION
This commit introduces a swipe-to-refresh functionality on the Home screen, allowing users to refresh all data sections simultaneously. It also includes several UI and logic improvements for the Home screen and updates dependencies.

Specific changes:
- Added `isRefreshing` state to `HomeUiState` to manage the refresh indicator.
- Implemented `refreshAllData` in `HomeViewModel` to fetch all data concurrently.
- Integrated `PullRefreshIndicator` in `HomeScreenContent` for swipe-to-refresh.
- Updated `OrderStatusCard` to use `item.orderDate` instead of `item.dueDate` for display and added a string resource for "Order Date".
- Enhanced `HomeViewModelTest` with more comprehensive test cases, including tests for data fetching, error handling, sorting logic, and the new refresh functionality.
- Upgraded `compileSdk` and `targetSdk` to 36.
- Updated `google-services` to `4.4.3` and `firebase-appdistribution-api` to `16.0.0-beta17`.
- Removed `detekt` plugin from `app/build.gradle`.
- Adjusted loading indicators in `HomeScreenContent` to provide a better user experience during refresh and sort operations.
- Ensured `HomeViewModel`'s `init` block and data fetching methods correctly handle `Resource` states (Success, Error, Empty).