### PR TITLE
feat: Implement search functionality in HomeScreen and enhance ViewMo…

### DIFF
--- a/app/src/main/java/com/raylabs/laundryhub/ui/home/state/HomeUiState.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/home/state/HomeUiState.kt
@@ -18,5 +18,7 @@ data class HomeUiState(
     val unpaidOrder: SectionState<List<UnpaidOrderItem>> = SectionState(),
     val detailOrder: SectionState<TransactionItem> = SectionState(),
     val currentSortOption: SortOption = SortOption.ORDER_DATE_DESC, // Default sort option
-    val isRefreshing: Boolean = false // Added for swipe-to-refresh
+    val isRefreshing: Boolean = false, // Added for swipe-to-refresh
+    val searchQuery: String = "", // Added for search functionality
+    val isSearchActive: Boolean = false // Added for search functionality
 )

--- a/app/src/main/java/com/raylabs/laundryhub/ui/theme/Color.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/theme/Color.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.graphics.Color
 val Purple200 = Color(0xFFBB86FC)
 val Purple500 = Color(0xFF6200EE)
 val Purple700 = Color(0xFF3700B3)
-val Purple800 = Color(0xFF4A4459)
 val Teal200 = Color(0xFF03DAC5)
 val RedLaundryHub = Color(0xFFB3261E)
 val PurpleLaundryHub = Color(0xFF6750A4)

--- a/app/src/main/java/com/raylabs/laundryhub/ui/theme/Theme.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/theme/Theme.kt
@@ -15,8 +15,8 @@ private val DarkColorPalette = darkColors(
     surface = Color(0xFFF5F5F5), // abu-abu terang agar bottom sheet tidak putih polos di dark mode
     onPrimary = Color.White,
     onSecondary = Color.Black,
-    onBackground = Color.White,
-    onSurface = Color.Black
+    onBackground = Color.White, // Teks di atas background utama (gelap) adalah PUTIH
+    onSurface = Color.Black    // Teks di atas surface (bottom sheet terang) adalah HITAM
 )
 
 private val LightColorPalette = lightColors(
@@ -24,11 +24,11 @@ private val LightColorPalette = lightColors(
     primaryVariant = Purple700,
     secondary = Teal200,
     background = Color.White,
-    surface = Color.White, // tetap putih di light mode
+    surface = Color.White, 
     onPrimary = Color.White,
     onSecondary = Color.Black,
-    onBackground = Color.Black,
-    onSurface = Color.Black
+    onBackground = Color.Black, // Teks di atas background utama (terang) adalah HITAM
+    onSurface = Color.Black    // Teks di atas surface (terang) adalah HITAM
 )
 
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,10 @@
     <string name="no_data">No Data</string>"
     <string name="hello">Hello,</string>
     <string name="order_date">Order Date</string>
+    <string name="open_search_view">Open Search</string>
+    <string name="close_search_view">Close Search</string>
+    <string name="clear_search">Clear Search</string>
+    <string name="search_icon">Search Icon</string>
+    <string name="search_customer_placeholder">Search Customer</string>
+    <string name="no_search_results">Data Not Found</string>
 </resources>


### PR DESCRIPTION
…del tests

This commit introduces search functionality to the HomeScreen, allowing users to filter pending orders by customer name. It also includes significant additions and improvements to the `HomeViewModelTest` and `OrderViewModelTest` for better coverage and reliability. Color definitions and string resources have also been updated.

Specific changes:
- Added search bar to `HomeScreenView` that appears when the search icon is clicked.
- Implemented search logic in `HomeViewModel` to filter unpaid orders.
- `HomeViewModel` now stores the original list of unpaid orders to re-apply filters and sorting without re-fetching.
- Updated `HomeUiState` to include `searchQuery` and `isSearchActive`.
- Enhanced `HomeViewModelTest` with tests for:
    - Search functionality (case-insensitivity, list updates).
    - Toggling search state (clearing query, restoring list).
    - Sorting with null or invalid dates.
    - Handling of `Resource.Empty` in `fetchTodayIncome` and `fetchSummary`.
- Added new tests to `OrderViewModelTest` for:
    - `fetchLastOrderId` error handling.
    - `getPackageList` error handling and package selection in edit mode.
    - `onOrderEditClick` for empty and loading states.
    - `submitOrder` and `updateOrder` for success and error scenarios.
    - `updateField` with unknown keys.
    - `recalculateWeight` when minPrice is zero.
- Modified `Theme.kt` to adjust `onBackground` and `onSurface` colors for dark and light themes.
- Removed unused `Purple800` from `Color.kt`.
- Added new string resources for search-related UI elements.
- Refactored `HomeViewModel` to handle `Resource.Empty` and `Resource.Loading` more explicitly in `fetchTodayIncomeFromInit` and `fetchSummaryFromInit`.
- Ensured `PullRefreshIndicator` and `LaunchedEffect` in `HomeScreenView` correctly handle UI updates and potential errors.
- Added new Preview composables for `HomeScreenContent` to showcase default and search-active states in both light and dark themes.