### PR TITLE
feat: Add comprehensive package management to Inventory

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -20,8 +20,8 @@ jobs:
 
       - name: Decode LaundryHub.jks
         env:
-          MYAPP_RELEASE_KEYSTORE_FILE_B64: ${{ secrets.MYAPP_RELEASE_KEYSTORE_FILE }}
-        run: printf '%s' "$MYAPP_RELEASE_KEYSTORE_FILE" | base64 --decode > ./app/laundry_hub_key.jks
+          KEYSTORE_FILE: ${{ secrets.KEYSTORE_FILE }}
+        run: printf '%s' "$KEYSTORE_FILE" | base64 --decode > ./app/laundry_hub_key.jks
 
       - name: Decode google-services.json
         env:
@@ -97,67 +97,8 @@ jobs:
           distribution: 'zulu'
           java-version: '18'
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
-
       - name: Grant execute permission for Gradlew
         run: chmod +x ./gradlew
-
-      - name: Warm Gradle wrapper
-        run: |
-          for attempt in 1 2 3; do
-            ./gradlew --version && exit 0
-            echo "Gradle wrapper bootstrap failed on attempt $attempt"
-            sleep 10
-          done
-          exit 1
-
-      - name: Verify release keystore metadata
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          get_config_value() {
-            local key="$1"
-            local value
-            value="$(grep "^${key}=" config.properties | cut -d= -f2- || true)"
-            printf '%s' "$value"
-          }
-
-          KEYSTORE_FILE="$(get_config_value MYAPP_RELEASE_KEYSTORE_FILE)"
-          KEYSTORE_PASSWORD="$(get_config_value MYAPP_RELEASE_KEYSTORE_PASSWORD)"
-          KEY_ALIAS="$(get_config_value MYAPP_RELEASE_KEY_ALIAS)"
-
-          if [[ -z "$KEYSTORE_FILE" || -z "$KEYSTORE_PASSWORD" || -z "$KEY_ALIAS" ]]; then
-            echo "Release signing config is incomplete in config.properties."
-            exit 1
-          fi
-
-          KEYSTORE_PATH="$KEYSTORE_FILE"
-          if [[ ! -f "$KEYSTORE_PATH" ]]; then
-            KEYSTORE_PATH="./app/${KEYSTORE_FILE#./}"
-          fi
-
-          if [[ ! -f "$KEYSTORE_PATH" ]]; then
-            echo "Keystore file not found. Expected one of:"
-            echo "- $KEYSTORE_FILE"
-            echo "- ./app/${KEYSTORE_FILE#./}"
-            exit 1
-          fi
-
-          if ! keytool -list -keystore "$KEYSTORE_PATH" -storepass "$KEYSTORE_PASSWORD" > /dev/null 2>&1; then
-            echo "Release keystore could not be opened."
-            echo "Check whether MYAPP_RELEASE_KEYSTORE_FILE_B64 and MYAPP_RELEASE_KEYSTORE_PASSWORD match the same keystore."
-            exit 1
-          fi
-
-          if ! keytool -list -keystore "$KEYSTORE_PATH" -alias "$KEY_ALIAS" -storepass "$KEYSTORE_PASSWORD" > /dev/null 2>&1; then
-            echo "Release keystore opened, but the configured alias was not found."
-            echo "Check whether MYAPP_RELEASE_KEY_ALIAS matches the alias inside the uploaded keystore."
-            exit 1
-          fi
-
-          echo "Release keystore metadata verified."
 
       - name: Build APK
         run: ./gradlew assembleRelease
@@ -239,68 +180,9 @@ jobs:
           distribution: 'zulu'
           java-version: '18'
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
-
       # Step 4: Grant execute permission for Gradlew
       - name: Grant execute permission for Gradlew
         run: chmod +x ./gradlew
-
-      - name: Warm Gradle wrapper
-        run: |
-          for attempt in 1 2 3; do
-            ./gradlew --version && exit 0
-            echo "Gradle wrapper bootstrap failed on attempt $attempt"
-            sleep 10
-          done
-          exit 1
-
-      - name: Verify release keystore metadata
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          get_config_value() {
-            local key="$1"
-            local value
-            value="$(grep "^${key}=" config.properties | cut -d= -f2- || true)"
-            printf '%s' "$value"
-          }
-
-          KEYSTORE_FILE="$(get_config_value MYAPP_RELEASE_KEYSTORE_FILE)"
-          KEYSTORE_PASSWORD="$(get_config_value MYAPP_RELEASE_KEYSTORE_PASSWORD)"
-          KEY_ALIAS="$(get_config_value MYAPP_RELEASE_KEY_ALIAS)"
-
-          if [[ -z "$KEYSTORE_FILE" || -z "$KEYSTORE_PASSWORD" || -z "$KEY_ALIAS" ]]; then
-            echo "Release signing config is incomplete in config.properties."
-            exit 1
-          fi
-
-          KEYSTORE_PATH="$KEYSTORE_FILE"
-          if [[ ! -f "$KEYSTORE_PATH" ]]; then
-            KEYSTORE_PATH="./app/${KEYSTORE_FILE#./}"
-          fi
-
-          if [[ ! -f "$KEYSTORE_PATH" ]]; then
-            echo "Keystore file not found. Expected one of:"
-            echo "- $KEYSTORE_FILE"
-            echo "- ./app/${KEYSTORE_FILE#./}"
-            exit 1
-          fi
-
-          if ! keytool -list -keystore "$KEYSTORE_PATH" -storepass "$KEYSTORE_PASSWORD" > /dev/null 2>&1; then
-            echo "Release keystore could not be opened."
-            echo "Check whether MYAPP_RELEASE_KEYSTORE_FILE_B64 and MYAPP_RELEASE_KEYSTORE_PASSWORD match the same keystore."
-            exit 1
-          fi
-
-          if ! keytool -list -keystore "$KEYSTORE_PATH" -alias "$KEY_ALIAS" -storepass "$KEYSTORE_PASSWORD" > /dev/null 2>&1; then
-            echo "Release keystore opened, but the configured alias was not found."
-            echo "Check whether MYAPP_RELEASE_KEY_ALIAS matches the alias inside the uploaded keystore."
-            exit 1
-          fi
-
-          echo "Release keystore metadata verified."
 
       # Step 5: Build APK (Release)
       - name: Build APK (Release)
@@ -346,20 +228,8 @@ jobs:
           distribution: 'zulu'
           java-version: '18'
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@0b6dd653ba04f4f93bf581ec31e66cbd7dcb644d # v4
-
       - name: Grant execute permission for Gradlew
         run: chmod +x ./gradlew
-
-      - name: Warm Gradle wrapper
-        run: |
-          for attempt in 1 2 3; do
-            ./gradlew --version && exit 0
-            echo "Gradle wrapper bootstrap failed on attempt $attempt"
-            sleep 10
-          done
-          exit 1
 
       - name: Run tests and generate Jacoco report
         run: ./gradlew clean testDebugUnitTest jacocoTestReport

--- a/app/src/main/java/com/raylabs/laundryhub/core/data/repository/GoogleSheetRepositoryImpl.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/core/data/repository/GoogleSheetRepositoryImpl.kt
@@ -48,9 +48,11 @@ class GoogleSheetRepositoryImpl @Inject constructor(
         private const val GROSS_RANGE = "gross!A1:D"
         private const val INCOME_RANGE = "income!A1:N"
         private const val PACKAGE_RANGE = "notes!A1:D"
+        private const val PACKAGE_WRITE_RANGE = "notes!A:D"
         private const val INCOME_REMARKS_RANGE = "income!I2:I"
         private const val ORDER_ID_RANGE = "income!A2:A"
         private const val OUTCOME_RANGE = "outcome!A1:F"
+        private const val PACKAGE_SHEET_NAME = "notes"
 
         private const val SHEET_APPEND_DATA = "USER_ENTERED"
     }
@@ -169,11 +171,11 @@ class GoogleSheetRepositoryImpl @Inject constructor(
                         val headers = response.getValues().firstOrNull() ?: emptyList()
                         val dataRows = response.getValues().drop(1)
 
-                        val data = dataRows.map { row ->
+                        val data = dataRows.mapIndexed { index, row ->
                             val mappedRow = headers.zip(row).associate {
                                 it.first.toString() to it.second?.toString().orEmpty()
                             }
-                            mappedRow.toPackageData()
+                            mappedRow.toPackageData(sheetRowIndex = index + 2)
                         }
 
                         if (data.isEmpty()) Resource.Empty else Resource.Success(data)
@@ -181,6 +183,66 @@ class GoogleSheetRepositoryImpl @Inject constructor(
                         GSheetRepositoryErrorHandling.handleGoogleJsonResponseException(e)
                     } catch (e: Exception) {
                         GSheetRepositoryErrorHandling.handleReadSheetResponseException(e)
+                    }
+                } ?: GSheetRepositoryErrorHandling.handleFailAfterRetry()
+            }
+        }
+    }
+
+    override suspend fun addPackage(packageData: PackageData): Resource<Boolean> {
+        return withContext(Dispatchers.IO) {
+            withConfiguredSpreadsheetId { spreadsheetId ->
+                retry {
+                    try {
+                        val body = ValueRange().setValues(packageData.toSheetValues())
+                        handlingSuccessAppendSheet(spreadsheetId, body, PACKAGE_WRITE_RANGE)
+                    } catch (e: Exception) {
+                        GSheetRepositoryErrorHandling.handleFailedAddOrder(e)
+                    }
+                } ?: GSheetRepositoryErrorHandling.handleFailAfterRetry()
+            }
+        }
+    }
+
+    override suspend fun updatePackage(packageData: PackageData): Resource<Boolean> {
+        return withContext(Dispatchers.IO) {
+            withConfiguredSpreadsheetId { spreadsheetId ->
+                retry {
+                    try {
+                        if (packageData.sheetRowIndex < 2) {
+                            return@retry Resource.Error("Package row not found.")
+                        }
+
+                        val body = ValueRange().setValues(packageData.toSheetValues())
+                        handlingSuccessUpdateSheet(
+                            spreadsheetId = spreadsheetId,
+                            valueRange = body,
+                            range = "notes!A${packageData.sheetRowIndex}:D"
+                        )
+                    } catch (e: Exception) {
+                        GSheetRepositoryErrorHandling.handleFailedUpdate(e)
+                    }
+                } ?: GSheetRepositoryErrorHandling.handleFailAfterRetry()
+            }
+        }
+    }
+
+    override suspend fun deletePackage(sheetRowIndex: Int): Resource<Boolean> {
+        return withContext(Dispatchers.IO) {
+            withConfiguredSpreadsheetId { spreadsheetId ->
+                retry {
+                    try {
+                        if (sheetRowIndex < 2) {
+                            return@retry Resource.Error("Package row not found.")
+                        }
+
+                        deleteSheetRow(
+                            spreadsheetId = spreadsheetId,
+                            sheetName = PACKAGE_SHEET_NAME,
+                            rowIndex = sheetRowIndex - 2
+                        )
+                    } catch (e: Exception) {
+                        GSheetRepositoryErrorHandling.handleFailedDelete(e)
                     }
                 } ?: GSheetRepositoryErrorHandling.handleFailAfterRetry()
             }

--- a/app/src/main/java/com/raylabs/laundryhub/core/di/GSheetModule.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/core/di/GSheetModule.kt
@@ -8,10 +8,13 @@ import com.raylabs.laundryhub.core.domain.repository.GoogleSheetRepository
 import com.raylabs.laundryhub.core.domain.repository.SpreadsheetIdProvider
 import com.raylabs.laundryhub.core.domain.repository.SpreadsheetValidationRepository
 import com.raylabs.laundryhub.core.domain.usecase.settings.ValidateSpreadsheetUseCase
+import com.raylabs.laundryhub.core.domain.usecase.sheets.DeletePackageUseCase
 import com.raylabs.laundryhub.core.domain.usecase.sheets.GetOtherPackageUseCase
 import com.raylabs.laundryhub.core.domain.usecase.sheets.ReadGrossDataUseCase
 import com.raylabs.laundryhub.core.domain.usecase.sheets.ReadPackageUseCase
 import com.raylabs.laundryhub.core.domain.usecase.sheets.ReadSpreadsheetDataUseCase
+import com.raylabs.laundryhub.core.domain.usecase.sheets.SubmitPackageUseCase
+import com.raylabs.laundryhub.core.domain.usecase.sheets.UpdatePackageUseCase
 import com.raylabs.laundryhub.core.domain.usecase.sheets.income.DeleteOrderUseCase
 import com.raylabs.laundryhub.core.domain.usecase.sheets.income.GetLastOrderIdUseCase
 import com.raylabs.laundryhub.core.domain.usecase.sheets.income.GetOrderUseCase
@@ -74,6 +77,21 @@ object GSheetModule {
     @ViewModelScoped
     fun provideGetOtherPackageUseCase(repository: GoogleSheetRepository): GetOtherPackageUseCase =
         GetOtherPackageUseCase(repository)
+
+    @Provides
+    @ViewModelScoped
+    fun provideSubmitPackageUseCase(repository: GoogleSheetRepository): SubmitPackageUseCase =
+        SubmitPackageUseCase(repository)
+
+    @Provides
+    @ViewModelScoped
+    fun provideUpdatePackageUseCase(repository: GoogleSheetRepository): UpdatePackageUseCase =
+        UpdatePackageUseCase(repository)
+
+    @Provides
+    @ViewModelScoped
+    fun provideDeletePackageUseCase(repository: GoogleSheetRepository): DeletePackageUseCase =
+        DeletePackageUseCase(repository)
 
     @Provides
     @ViewModelScoped

--- a/app/src/main/java/com/raylabs/laundryhub/core/domain/model/sheets/PackageData.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/core/domain/model/sheets/PackageData.kt
@@ -4,14 +4,27 @@ data class PackageData(
     val price: String,
     val name: String,
     val duration: String,
-    val unit: String
+    val unit: String,
+    val sheetRowIndex: Int = -1
 )
 
-fun Map<String, String>.toPackageData(): PackageData {
+fun Map<String, String>.toPackageData(sheetRowIndex: Int = -1): PackageData {
     return PackageData(
         price = (this["harga"] ?: "").toString(),
         name = (this["packages"] ?: "").toString(),
         duration = (this["work"] ?: "").toString(),
-        unit = (this["unit"] ?: "").toString()
+        unit = (this["unit"] ?: "").toString(),
+        sheetRowIndex = sheetRowIndex
+    )
+}
+
+fun PackageData.toSheetValues(): List<List<String>> {
+    return listOf(
+        listOf(
+            this.price,
+            this.name,
+            this.duration,
+            this.unit
+        )
     )
 }

--- a/app/src/main/java/com/raylabs/laundryhub/core/domain/repository/GoogleSheetRepository.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/core/domain/repository/GoogleSheetRepository.kt
@@ -19,6 +19,9 @@ interface GoogleSheetRepository {
     ): Resource<List<TransactionData>>
 
     suspend fun readPackageData(): Resource<List<PackageData>>
+    suspend fun addPackage(packageData: PackageData): Resource<Boolean>
+    suspend fun updatePackage(packageData: PackageData): Resource<Boolean>
+    suspend fun deletePackage(sheetRowIndex: Int): Resource<Boolean>
     suspend fun readOtherPackage(): Resource<List<String>>
     suspend fun getLastOrderId(): Resource<String>
     suspend fun addOrder(order: OrderData): Resource<Boolean>

--- a/app/src/main/java/com/raylabs/laundryhub/core/domain/usecase/sheets/DeletePackageUseCase.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/core/domain/usecase/sheets/DeletePackageUseCase.kt
@@ -1,0 +1,23 @@
+package com.raylabs.laundryhub.core.domain.usecase.sheets
+
+import com.raylabs.laundryhub.core.domain.repository.GoogleSheetRepository
+import com.raylabs.laundryhub.core.domain.usecase.UseCaseErrorHandling
+import com.raylabs.laundryhub.ui.common.util.Resource
+import com.raylabs.laundryhub.ui.common.util.retry
+
+class DeletePackageUseCase(
+    private val repository: GoogleSheetRepository
+) {
+    suspend operator fun invoke(
+        onRetry: ((Int) -> Unit)? = null,
+        sheetRowIndex: Int
+    ): Resource<Boolean> {
+        if (sheetRowIndex < 2) {
+            return Resource.Error("Package row not found.")
+        }
+
+        return retry(onRetry = onRetry) {
+            repository.deletePackage(sheetRowIndex)
+        } ?: UseCaseErrorHandling.handleFailedSubmit
+    }
+}

--- a/app/src/main/java/com/raylabs/laundryhub/core/domain/usecase/sheets/GetOtherPackageUseCase.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/core/domain/usecase/sheets/GetOtherPackageUseCase.kt
@@ -15,14 +15,16 @@ class GetOtherPackageUseCase @Inject constructor(
         if (packageResult is Resource.Error) return Resource.Error(packageResult.message)
 
         val remarks = (remarkResult as? Resource.Success)?.data.orEmpty()
-            .map { it.trim() }
+            .map(::normalizePackageLabel)
 
         val packages = (packageResult as? Resource.Success)?.data.orEmpty()
-            .map { it.name }
+            .map { normalizePackageKey(it.name) }
 
+        val seenPackageKeys = mutableSetOf<String>()
         val otherPackages = remarks
-            .filter { it.isNotBlank() && it !in packages }
-            .distinct()
+            .filter { it.isNotBlank() }
+            .filterNot { normalizePackageKey(it) in packages }
+            .filter { seenPackageKeys.add(normalizePackageKey(it)) }
 
         return if (otherPackages.isEmpty()) {
             Resource.Empty
@@ -31,3 +33,9 @@ class GetOtherPackageUseCase @Inject constructor(
         }
     }
 }
+
+private fun normalizePackageLabel(value: String): String =
+    value.trim().replace(Regex("\\s+"), " ")
+
+private fun normalizePackageKey(value: String): String =
+    normalizePackageLabel(value).lowercase()

--- a/app/src/main/java/com/raylabs/laundryhub/core/domain/usecase/sheets/PackageMutationValidation.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/core/domain/usecase/sheets/PackageMutationValidation.kt
@@ -1,0 +1,32 @@
+package com.raylabs.laundryhub.core.domain.usecase.sheets
+
+import com.raylabs.laundryhub.core.domain.model.sheets.PackageData
+import com.raylabs.laundryhub.ui.common.util.Resource
+
+internal fun validatePackageForSave(packageData: PackageData): Resource.Error? {
+    return when {
+        packageData.name.isBlank() -> Resource.Error("Package name is required.")
+        packageData.price.isBlank() -> Resource.Error("Package price is required.")
+        packageData.duration.isBlank() -> Resource.Error("Package duration is required.")
+        packageData.unit.isBlank() -> Resource.Error("Package unit is required.")
+        else -> null
+    }
+}
+
+internal fun hasDuplicatePackageName(
+    packageName: String,
+    existingPackages: List<PackageData>,
+    excludingRowIndex: Int? = null
+): Boolean {
+    val normalizedTarget = normalizePackageName(packageName)
+    return existingPackages.any { item ->
+        item.sheetRowIndex != excludingRowIndex &&
+            normalizePackageName(item.name) == normalizedTarget
+    }
+}
+
+private fun normalizePackageName(value: String): String {
+    return value.trim()
+        .replace(Regex("\\s+"), " ")
+        .lowercase()
+}

--- a/app/src/main/java/com/raylabs/laundryhub/core/domain/usecase/sheets/SubmitPackageUseCase.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/core/domain/usecase/sheets/SubmitPackageUseCase.kt
@@ -1,0 +1,33 @@
+package com.raylabs.laundryhub.core.domain.usecase.sheets
+
+import com.raylabs.laundryhub.core.domain.model.sheets.PackageData
+import com.raylabs.laundryhub.core.domain.repository.GoogleSheetRepository
+import com.raylabs.laundryhub.core.domain.usecase.UseCaseErrorHandling
+import com.raylabs.laundryhub.ui.common.util.Resource
+import com.raylabs.laundryhub.ui.common.util.retry
+
+class SubmitPackageUseCase(
+    private val repository: GoogleSheetRepository
+) {
+    suspend operator fun invoke(
+        onRetry: ((Int) -> Unit)? = null,
+        packageData: PackageData
+    ): Resource<Boolean> {
+        validatePackageForSave(packageData)?.let { return it }
+
+        when (val existingPackages = repository.readPackageData()) {
+            is Resource.Success -> {
+                if (hasDuplicatePackageName(packageData.name, existingPackages.data)) {
+                    return Resource.Error("Package name already exists in the master list.")
+                }
+            }
+
+            is Resource.Error -> return existingPackages
+            else -> Unit
+        }
+
+        return retry(onRetry = onRetry) {
+            repository.addPackage(packageData)
+        } ?: UseCaseErrorHandling.handleFailedSubmit
+    }
+}

--- a/app/src/main/java/com/raylabs/laundryhub/core/domain/usecase/sheets/UpdatePackageUseCase.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/core/domain/usecase/sheets/UpdatePackageUseCase.kt
@@ -1,0 +1,42 @@
+package com.raylabs.laundryhub.core.domain.usecase.sheets
+
+import com.raylabs.laundryhub.core.domain.model.sheets.PackageData
+import com.raylabs.laundryhub.core.domain.repository.GoogleSheetRepository
+import com.raylabs.laundryhub.core.domain.usecase.UseCaseErrorHandling
+import com.raylabs.laundryhub.ui.common.util.Resource
+import com.raylabs.laundryhub.ui.common.util.retry
+
+class UpdatePackageUseCase(
+    private val repository: GoogleSheetRepository
+) {
+    suspend operator fun invoke(
+        onRetry: ((Int) -> Unit)? = null,
+        packageData: PackageData
+    ): Resource<Boolean> {
+        if (packageData.sheetRowIndex < 2) {
+            return Resource.Error("Package row not found.")
+        }
+
+        validatePackageForSave(packageData)?.let { return it }
+
+        when (val existingPackages = repository.readPackageData()) {
+            is Resource.Success -> {
+                if (hasDuplicatePackageName(
+                        packageName = packageData.name,
+                        existingPackages = existingPackages.data,
+                        excludingRowIndex = packageData.sheetRowIndex
+                    )
+                ) {
+                    return Resource.Error("Package name already exists in the master list.")
+                }
+            }
+
+            is Resource.Error -> return existingPackages
+            else -> Unit
+        }
+
+        return retry(onRetry = onRetry) {
+            repository.updatePackage(packageData)
+        } ?: UseCaseErrorHandling.handleFailedSubmit
+    }
+}

--- a/app/src/main/java/com/raylabs/laundryhub/ui/LaundryHubStarter.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/LaundryHubStarter.kt
@@ -528,7 +528,9 @@ fun LaundryHubStarter(
                     )
                 }
                 composable(INVENTORY_ROUTE) {
-                    InventoryScreenView()
+                    InventoryScreenView(
+                        onBackClick = { navController.popBackStack() }
+                    )
                 }
                 composable(GROSS_ROUTE) {
                     val state by homeViewModel.uiState.collectAsState()

--- a/app/src/main/java/com/raylabs/laundryhub/ui/common/dummy/inventory/DummyInventoryUiState.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/common/dummy/inventory/DummyInventoryUiState.kt
@@ -7,11 +7,11 @@ import com.raylabs.laundryhub.ui.profile.inventory.state.PackageItem
 val dummyInventoryUiState = InventoryUiState(
     packages = SectionState(
         data = listOf(
-            PackageItem("Regular", "Rp 5.000 ,-", "3d"),
-            PackageItem("Express - 6H", "Rp 10.000 ,-", "6h"),
-            PackageItem("Express - 24H", "Rp 8.000 ,-", "1d"),
-            PackageItem("Regular Cuci", "Rp 3.000 ,-", "3d"),
-            PackageItem("Express - 6H Cuci", "Rp 5.000 ,-", "6h")
+            PackageItem("Regular", "Rp5.000", "3d", "kg"),
+            PackageItem("Express - 6H", "Rp10.000", "6h", "kg"),
+            PackageItem("Express - 24H", "Rp8.000", "1d", "kg"),
+            PackageItem("Regular Cuci", "Rp3.000", "3d", "kg"),
+            PackageItem("Express - 6H Cuci", "Rp7.000", "6h", "kg")
         )
     ),
     otherPackages = SectionState(

--- a/app/src/main/java/com/raylabs/laundryhub/ui/component/DefaultTopAppbar.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/component/DefaultTopAppbar.kt
@@ -4,18 +4,27 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.raylabs.laundryhub.R
 import com.raylabs.laundryhub.ui.theme.PurpleLaundryHub
 
 @Composable
-fun DefaultTopAppBar(title: String) {
+fun DefaultTopAppBar(
+    title: String,
+    onBackClick: (() -> Unit)? = null
+) {
     Box(
         modifier = Modifier
             .background(PurpleLaundryHub)
@@ -28,6 +37,16 @@ fun DefaultTopAppBar(title: String) {
                     text = title,
                     style = MaterialTheme.typography.h6
                 )
+            },
+            navigationIcon = onBackClick?.let {
+                {
+                    IconButton(onClick = it) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.back)
+                        )
+                    }
+                }
             },
             backgroundColor = PurpleLaundryHub,
             contentColor = Color.White,

--- a/app/src/main/java/com/raylabs/laundryhub/ui/component/InventoryPackageSheets.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/component/InventoryPackageSheets.kt
@@ -1,0 +1,459 @@
+package com.raylabs.laundryhub.ui.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.raylabs.laundryhub.R
+import com.raylabs.laundryhub.ui.profile.inventory.state.PackageItem
+import com.raylabs.laundryhub.ui.theme.LaundryHubTheme
+import com.raylabs.laundryhub.ui.theme.appBorderSoft
+import com.raylabs.laundryhub.ui.theme.appErrorContainer
+import com.raylabs.laundryhub.ui.theme.appErrorContent
+import com.raylabs.laundryhub.ui.theme.appInfoContainer
+import com.raylabs.laundryhub.ui.theme.appInfoContent
+import com.raylabs.laundryhub.ui.theme.modalSheetTop
+
+private enum class InventoryPackageAction {
+    Edit,
+    Delete
+}
+
+@Composable
+fun InventoryPackageActionSheet(
+    visible: Boolean,
+    packageItem: PackageItem?,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (!visible || packageItem == null) return
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colors.onSurface.copy(alpha = 0.38f))
+    ) {
+        Spacer(
+            modifier = Modifier
+                .fillMaxSize()
+                .clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() }
+                ) {
+                    onDismiss()
+                }
+        )
+
+        Surface(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .navigationBarsPadding(),
+            shape = MaterialTheme.shapes.modalSheetTop,
+            color = MaterialTheme.colors.surface,
+            contentColor = MaterialTheme.colors.onSurface,
+            elevation = 10.dp
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 18.dp),
+                verticalArrangement = Arrangement.spacedBy(14.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .size(width = 40.dp, height = 4.dp)
+                        .background(
+                            MaterialTheme.colors.onSurface.copy(alpha = 0.18f),
+                            shape = CircleShape
+                        )
+                )
+
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    Text(
+                        text = packageItem.name,
+                        style = MaterialTheme.typography.h6,
+                        color = MaterialTheme.colors.onSurface
+                    )
+                    Text(
+                        text = packageItem.displayRate,
+                        style = MaterialTheme.typography.body2,
+                        color = MaterialTheme.colors.onSurface.copy(alpha = 0.72f)
+                    )
+                }
+
+                InventoryPackageActionRow(
+                    action = InventoryPackageAction.Edit,
+                    onClick = onEdit
+                )
+
+                InventoryPackageActionRow(
+                    action = InventoryPackageAction.Delete,
+                    onClick = onDelete
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun InventoryPackageDeleteConfirmationSheet(
+    visible: Boolean,
+    packageItem: PackageItem?,
+    isDeleting: Boolean,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (!visible || packageItem == null) return
+
+    AppConfirmationSheet(
+        title = stringResource(R.string.inventory_package_delete_confirmation_title),
+        message = stringResource(
+            R.string.inventory_package_delete_confirmation_message,
+            packageItem.name
+        ),
+        confirmLabel = stringResource(
+            if (isDeleting) R.string.deleting else R.string.delete
+        ),
+        dismissLabel = stringResource(R.string.cancel),
+        onConfirm = {
+            if (!isDeleting) onConfirm()
+        },
+        onDismiss = {
+            if (!isDeleting) onDismiss()
+        },
+        modifier = modifier,
+        icon = Icons.Default.Delete,
+        bulletPoints = listOf(
+            stringResource(R.string.inventory_package_delete_point_permanent),
+            stringResource(R.string.inventory_package_delete_point_orders)
+        )
+    )
+}
+
+@Composable
+fun InventoryPackageEditorSheet(
+    visible: Boolean,
+    isEditMode: Boolean,
+    packageName: String,
+    packagePrice: String,
+    packageDuration: String,
+    packageUnit: String,
+    isSaveEnabled: Boolean,
+    isSubmitting: Boolean,
+    onPackageNameChange: (String) -> Unit,
+    onPackagePriceChange: (String) -> Unit,
+    onPackageDurationChange: (String) -> Unit,
+    onPackageUnitChange: (String) -> Unit,
+    onDismiss: () -> Unit,
+    onSave: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (!visible) return
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colors.onSurface.copy(alpha = 0.38f))
+    ) {
+        Spacer(
+            modifier = Modifier
+                .fillMaxSize()
+                .clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() }
+                ) {
+                    if (!isSubmitting) onDismiss()
+                }
+        )
+
+        Surface(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .navigationBarsPadding(),
+            shape = MaterialTheme.shapes.modalSheetTop,
+            color = MaterialTheme.colors.surface,
+            contentColor = MaterialTheme.colors.onSurface,
+            elevation = 10.dp
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 18.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .size(width = 40.dp, height = 4.dp)
+                        .background(
+                            MaterialTheme.colors.onSurface.copy(alpha = 0.18f),
+                            shape = CircleShape
+                        )
+                )
+
+                Text(
+                    text = stringResource(
+                        if (isEditMode) {
+                            R.string.inventory_package_editor_update_title
+                        } else {
+                            R.string.inventory_package_editor_add_title
+                        }
+                    ),
+                    style = MaterialTheme.typography.h6,
+                    fontWeight = FontWeight.Bold
+                )
+
+                OutlinedTextField(
+                    value = packageName,
+                    onValueChange = { onPackageNameChange(it.take(40)) },
+                    label = { Text(stringResource(R.string.inventory_package_field_name)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next),
+                    enabled = !isSubmitting
+                )
+
+                OutlinedTextField(
+                    value = packagePrice,
+                    onValueChange = { rawInput ->
+                        onPackagePriceChange(rawInput.filter(Char::isDigit).take(8))
+                    },
+                    label = { Text(stringResource(R.string.inventory_package_field_price)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    leadingIcon = {
+                        Text(
+                            text = stringResource(R.string.currency_prefix_rupiah),
+                            modifier = Modifier.padding(start = 4.dp)
+                        )
+                    },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions.Default.copy(
+                        imeAction = ImeAction.Next,
+                        keyboardType = KeyboardType.Number
+                    ),
+                    enabled = !isSubmitting
+                )
+
+                OutlinedTextField(
+                    value = packageDuration,
+                    onValueChange = { onPackageDurationChange(it.take(20)) },
+                    label = { Text(stringResource(R.string.inventory_package_field_duration)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Next),
+                    enabled = !isSubmitting
+                )
+
+                Text(
+                    text = stringResource(R.string.inventory_package_duration_hint),
+                    style = MaterialTheme.typography.caption,
+                    color = MaterialTheme.colors.onSurface.copy(alpha = 0.68f)
+                )
+
+                OutlinedTextField(
+                    value = packageUnit,
+                    onValueChange = { onPackageUnitChange(it.take(10)) },
+                    label = { Text(stringResource(R.string.inventory_package_field_unit)) },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
+                    enabled = !isSubmitting
+                )
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    OutlinedButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.weight(1f),
+                        enabled = !isSubmitting,
+                        border = BorderStroke(1.dp, MaterialTheme.colors.appBorderSoft)
+                    ) {
+                        Text(text = stringResource(R.string.cancel))
+                    }
+
+                    Button(
+                        onClick = onSave,
+                        modifier = Modifier.weight(1f),
+                        enabled = isSaveEnabled && !isSubmitting,
+                        colors = ButtonDefaults.buttonColors(
+                            backgroundColor = MaterialTheme.colors.primary,
+                            contentColor = MaterialTheme.colors.onPrimary
+                        )
+                    ) {
+                        Text(
+                            text = stringResource(
+                                when {
+                                    isSubmitting && isEditMode -> R.string.updating
+                                    isSubmitting -> R.string.inventory_package_adding
+                                    isEditMode -> R.string.update
+                                    else -> R.string.inventory_package_add
+                                }
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InventoryPackageActionRow(
+    action: InventoryPackageAction,
+    onClick: () -> Unit
+) {
+    val isDelete = action == InventoryPackageAction.Delete
+    val title = if (isDelete) {
+        stringResource(R.string.inventory_package_action_delete_title)
+    } else {
+        stringResource(R.string.inventory_package_action_edit_title)
+    }
+
+    val leadingContainerColor = if (isDelete) {
+        MaterialTheme.colors.appErrorContainer
+    } else {
+        MaterialTheme.colors.appInfoContainer
+    }
+    val leadingContentColor = if (isDelete) {
+        MaterialTheme.colors.appErrorContent
+    } else {
+        MaterialTheme.colors.appInfoContent
+    }
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() },
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colors.surface,
+        border = BorderStroke(
+            1.dp,
+            MaterialTheme.colors.appBorderSoft
+        ),
+        elevation = 0.dp
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 14.dp, vertical = 14.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .background(leadingContainerColor, CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = if (isDelete) Icons.Default.Delete else Icons.Default.Edit,
+                    contentDescription = null,
+                    tint = leadingContentColor
+                )
+            }
+
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.body1,
+                    color = MaterialTheme.colors.onSurface
+                )
+            }
+
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colors.onSurface.copy(alpha = 0.48f)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewInventoryPackageActionSheet() {
+    LaundryHubTheme {
+        InventoryPackageActionSheet(
+            visible = true,
+            packageItem = PackageItem(
+                name = "Express - 6H",
+                price = "10000",
+                work = "6h",
+                unit = "kg",
+                sheetRowIndex = 2
+            ),
+            onEdit = {},
+            onDelete = {},
+            onDismiss = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewInventoryPackageEditorSheet() {
+    LaundryHubTheme {
+        InventoryPackageEditorSheet(
+            visible = true,
+            isEditMode = false,
+            packageName = "Express - 6H",
+            packagePrice = "10000",
+            packageDuration = "6h",
+            packageUnit = "kg",
+            isSaveEnabled = true,
+            isSubmitting = false,
+            onPackageNameChange = {},
+            onPackagePriceChange = {},
+            onPackageDurationChange = {},
+            onPackageUnitChange = {},
+            onDismiss = {},
+            onSave = {}
+        )
+    }
+}

--- a/app/src/main/java/com/raylabs/laundryhub/ui/component/SectionOrLoading.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/component/SectionOrLoading.kt
@@ -14,7 +14,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
@@ -40,7 +39,7 @@ fun SectionOrLoading(
         error != null && !hasContent -> {
             Text(
                 error,
-                color = Color.Red,
+                color = MaterialTheme.colors.error,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(16.dp),
@@ -75,7 +74,7 @@ fun SectionOrLoading(
                 if (error != null && hasContent) {
                     Text(
                         text = error,
-                        color = Color.Red,
+                        color = MaterialTheme.colors.error,
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(horizontal = 16.dp, vertical = 8.dp),

--- a/app/src/main/java/com/raylabs/laundryhub/ui/profile/inventory/InventoryScreenView.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/profile/inventory/InventoryScreenView.kt
@@ -5,150 +5,365 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Card
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
-import androidx.compose.material.SnackbarHostState
+import androidx.compose.material.SnackbarHost
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.raylabs.laundryhub.R
+import com.raylabs.laundryhub.core.domain.model.sheets.PackageData
 import com.raylabs.laundryhub.ui.common.dummy.inventory.dummyInventoryUiState
 import com.raylabs.laundryhub.ui.component.DefaultTopAppBar
 import com.raylabs.laundryhub.ui.component.InlineAdaptiveBannerAd
+import com.raylabs.laundryhub.ui.component.InlineAdaptiveBannerAdState
+import com.raylabs.laundryhub.ui.component.InventoryPackageActionSheet
+import com.raylabs.laundryhub.ui.component.InventoryPackageDeleteConfirmationSheet
+import com.raylabs.laundryhub.ui.component.InventoryPackageEditorSheet
 import com.raylabs.laundryhub.ui.component.SectionOrLoading
 import com.raylabs.laundryhub.ui.component.rememberInlineAdaptiveBannerAdState
 import com.raylabs.laundryhub.ui.profile.inventory.state.InventoryUiState
 import com.raylabs.laundryhub.ui.profile.inventory.state.PackageItem
+import com.raylabs.laundryhub.ui.theme.appBorderSoft
+import com.raylabs.laundryhub.ui.theme.appCardSurface
+import com.raylabs.laundryhub.ui.theme.appMutedContainer
+import com.raylabs.laundryhub.ui.theme.appMutedContent
+import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun InventoryScreenView(
-    viewModel: InventoryViewModel = hiltViewModel()
+    viewModel: InventoryViewModel = hiltViewModel(),
+    bannerState: InlineAdaptiveBannerAdState? = null,
+    onBackClick: (() -> Unit)? = null
 ) {
     val state = viewModel.uiState
+    val scaffoldState = rememberScaffoldState()
+    val resolvedBannerState = bannerState ?: rememberInlineAdaptiveBannerAdState("inventory_inline")
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+    val isSavingPackage = state.savePackage.isLoading
+    val isDeletingPackage = state.deletePackage.isLoading
+    var selectedPackage by remember { mutableStateOf<PackageItem?>(null) }
+    var packageEditorState by remember { mutableStateOf<InventoryPackageEditorState?>(null) }
+    var pendingDeletePackage by remember { mutableStateOf<PackageItem?>(null) }
+
+    LaunchedEffect(state.packages.errorMessage, state.otherPackages.errorMessage) {
+        listOfNotNull(state.packages.errorMessage, state.otherPackages.errorMessage)
+            .firstOrNull()
+            ?.let { message ->
+                scaffoldState.snackbarHostState.showSnackbar(message)
+            }
+    }
+
     Scaffold(
-        topBar = { DefaultTopAppBar("Inventory") }
+        scaffoldState = scaffoldState,
+        topBar = {
+            DefaultTopAppBar(
+                title = stringResource(R.string.inventory_title),
+                onBackClick = onBackClick
+            )
+        },
+        snackbarHost = { SnackbarHost(hostState = scaffoldState.snackbarHostState) }
     ) { padding ->
-        InventoryContent(state, modifier = Modifier.padding(padding))
-    }
-}
-
-@Composable
-fun InventoryContent(state: InventoryUiState, modifier: Modifier) {
-    val snackbarHostState = remember { SnackbarHostState() }
-    val bannerState = rememberInlineAdaptiveBannerAdState("inventory_inline")
-
-    LaunchedEffect(state) {
-        state.packages.errorMessage?.let {
-            snackbarHostState.showSnackbar(it)
-        }
-    }
-
-    LazyColumn(
-        modifier = modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(24.dp)
-    ) {
-        item {
-            SectionOrLoading(
-                isLoading = state.packages.isLoading,
-                error = state.packages.errorMessage,
-                hasContent = !state.packages.data.isNullOrEmpty(),
-                content = {
-                    SetupPackageSection(
-                        packages = state.packages.data.orEmpty(),
-                        modifier = modifier.padding(horizontal = 16.dp)
+        Box(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+        ) {
+            InventoryContent(
+                state = state,
+                bannerState = resolvedBannerState,
+                modifier = Modifier.fillMaxSize(),
+                isRefreshing = state.packages.isLoading || state.otherPackages.isLoading,
+                onRefresh = viewModel::refreshInventory,
+                onAddPackage = {
+                    packageEditorState = InventoryPackageEditorState()
+                },
+                onPackageClick = { item ->
+                    selectedPackage = item
+                },
+                onSuggestedPackageClick = { label ->
+                    packageEditorState = InventoryPackageEditorState(
+                        name = normalizeInventoryLabel(label)
                     )
                 }
             )
-        }
 
-        item(key = "inventory_inline_banner") {
-            InlineAdaptiveBannerAd(state = bannerState)
-        }
+            InventoryPackageActionSheet(
+                visible = selectedPackage != null,
+                packageItem = selectedPackage,
+                onEdit = {
+                    packageEditorState = selectedPackage?.toEditorState()
+                    selectedPackage = null
+                },
+                onDelete = {
+                    pendingDeletePackage = selectedPackage
+                    selectedPackage = null
+                },
+                onDismiss = { selectedPackage = null }
+            )
 
-        item {
-            SectionOrLoading(
-                isLoading = state.otherPackages.isLoading,
-                error = state.otherPackages.errorMessage,
-                hasContent = !state.otherPackages.data.isNullOrEmpty(),
-                content = {
-                    OtherPackagesSection(state.otherPackages.data.orEmpty(), modifier)
+            InventoryPackageDeleteConfirmationSheet(
+                visible = pendingDeletePackage != null,
+                packageItem = pendingDeletePackage,
+                isDeleting = isDeletingPackage,
+                onConfirm = {
+                    val item = pendingDeletePackage ?: return@InventoryPackageDeleteConfirmationSheet
+                    coroutineScope.launch {
+                        viewModel.deletePackage(
+                            sheetRowIndex = item.sheetRowIndex,
+                            onComplete = {
+                                pendingDeletePackage = null
+                                scaffoldState.snackbarHostState.showSnackbar(
+                                    context.getString(
+                                        R.string.inventory_package_delete_success,
+                                        item.name
+                                    )
+                                )
+                            },
+                            onError = { message ->
+                                scaffoldState.snackbarHostState.showSnackbar(
+                                    message.ifBlank {
+                                        context.getString(R.string.inventory_package_delete_failed)
+                                    }
+                                )
+                            }
+                        )
+                    }
+                },
+                onDismiss = {
+                    if (!isDeletingPackage) {
+                        pendingDeletePackage = null
+                    }
+                }
+            )
+
+            InventoryPackageEditorSheet(
+                visible = packageEditorState != null,
+                isEditMode = packageEditorState?.isEditMode == true,
+                packageName = packageEditorState?.name.orEmpty(),
+                packagePrice = packageEditorState?.price.orEmpty(),
+                packageDuration = packageEditorState?.duration.orEmpty(),
+                packageUnit = packageEditorState?.unit.orEmpty(),
+                isSaveEnabled = packageEditorState?.isSaveEnabled == true,
+                isSubmitting = isSavingPackage,
+                onPackageNameChange = { value ->
+                    packageEditorState = packageEditorState?.copy(name = value)
+                },
+                onPackagePriceChange = { value ->
+                    packageEditorState = packageEditorState?.copy(price = value)
+                },
+                onPackageDurationChange = { value ->
+                    packageEditorState = packageEditorState?.copy(duration = value)
+                },
+                onPackageUnitChange = { value ->
+                    packageEditorState = packageEditorState?.copy(unit = value)
+                },
+                onDismiss = {
+                    if (!isSavingPackage) {
+                        packageEditorState = null
+                    }
+                },
+                onSave = {
+                    val draft = packageEditorState ?: return@InventoryPackageEditorSheet
+                    coroutineScope.launch {
+                        if (draft.isEditMode) {
+                            viewModel.updatePackage(
+                                packageData = draft.toPackageData(),
+                                onComplete = {
+                                    packageEditorState = null
+                                    scaffoldState.snackbarHostState.showSnackbar(
+                                        context.getString(
+                                            R.string.inventory_package_update_success,
+                                            draft.name.trim()
+                                        )
+                                    )
+                                },
+                                onError = { message ->
+                                    scaffoldState.snackbarHostState.showSnackbar(
+                                        message.ifBlank {
+                                            context.getString(R.string.inventory_package_update_failed)
+                                        }
+                                    )
+                                }
+                            )
+                        } else {
+                            viewModel.submitPackage(
+                                packageData = draft.toPackageData(),
+                                onComplete = {
+                                    packageEditorState = null
+                                    scaffoldState.snackbarHostState.showSnackbar(
+                                        context.getString(
+                                            R.string.inventory_package_add_success,
+                                            draft.name.trim()
+                                        )
+                                    )
+                                },
+                                onError = { message ->
+                                    scaffoldState.snackbarHostState.showSnackbar(
+                                        message.ifBlank {
+                                            context.getString(R.string.inventory_package_add_failed)
+                                        }
+                                    )
+                                }
+                            )
+                        }
+                    }
                 }
             )
         }
     }
 }
 
+@OptIn(ExperimentalMaterialApi::class, ExperimentalLayoutApi::class)
 @Composable
-fun OtherPackagesSection(data: List<String>, modifier: Modifier) {
+fun InventoryContent(
+    state: InventoryUiState,
+    bannerState: InlineAdaptiveBannerAdState,
+    modifier: Modifier,
+    isRefreshing: Boolean = false,
+    onRefresh: () -> Unit = {},
+    onAddPackage: () -> Unit = {},
+    onPackageClick: (PackageItem) -> Unit = {},
+    onSuggestedPackageClick: (String) -> Unit = {}
+) {
+    val pullRefreshState = rememberPullRefreshState(
+        refreshing = isRefreshing,
+        onRefresh = onRefresh
+    )
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .pullRefresh(pullRefreshState)
+    ) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+            contentPadding = PaddingValues(top = 16.dp, bottom = 96.dp)
+        ) {
+            item {
+                SectionOrLoading(
+                    isLoading = state.packages.isLoading,
+                    error = state.packages.errorMessage,
+                    hasContent = !state.packages.data.isNullOrEmpty(),
+                    content = {
+                        SetupPackageSection(
+                            packages = state.packages.data.orEmpty(),
+                            modifier = Modifier.padding(horizontal = 16.dp),
+                            onAddPackage = onAddPackage,
+                            onPackageClick = onPackageClick
+                        )
+                    }
+                )
+            }
+
+            item(key = "inventory_inline_banner") {
+                InlineAdaptiveBannerAd(state = bannerState)
+            }
+
+            item {
+                SectionOrLoading(
+                    isLoading = state.otherPackages.isLoading,
+                    error = state.otherPackages.errorMessage,
+                    hasContent = !state.otherPackages.data.isNullOrEmpty(),
+                    content = {
+                        OtherPackagesSection(
+                            data = state.otherPackages.data.orEmpty(),
+                            modifier = Modifier.padding(horizontal = 16.dp),
+                            onPackageSuggestionClick = onSuggestedPackageClick
+                        )
+                    }
+                )
+            }
+        }
+
+        PullRefreshIndicator(
+            refreshing = isRefreshing,
+            state = pullRefreshState,
+            modifier = Modifier.align(Alignment.TopCenter)
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun OtherPackagesSection(
+    data: List<String>,
+    modifier: Modifier,
+    onPackageSuggestionClick: (String) -> Unit = {}
+) {
     Column(
-        modifier = modifier.padding(horizontal = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         Text(
-            text = "Others Package",
+            text = stringResource(R.string.inventory_unmapped_title),
             style = MaterialTheme.typography.h6,
             fontWeight = FontWeight.Bold
         )
         Text(
-            text = "The Other Package maybe you can configure the price",
+            text = stringResource(R.string.inventory_unmapped_description),
             style = MaterialTheme.typography.body2,
-            color = Color.Gray
+            color = MaterialTheme.colors.appMutedContent
         )
 
-        Spacer(Modifier.height(8.dp))
-
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .heightIn(max = 200.dp) // Batasi tinggi maksimal
-        ) {
-            LazyVerticalGrid(
-                columns = GridCells.Adaptive(minSize = 100.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                userScrollEnabled = false,
+        if (data.isEmpty()) {
+            InventoryInfoCard(
+                body = stringResource(R.string.inventory_unmapped_empty_body),
                 modifier = Modifier.fillMaxWidth()
+            )
+        } else {
+            Text(
+                text = stringResource(R.string.inventory_unmapped_tap_hint),
+                style = MaterialTheme.typography.caption,
+                color = MaterialTheme.colors.appMutedContent
+            )
+
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                items(
-                    items = data,
-                    key = { it }
-                ) { label ->
-                    Text(
-                        text = label,
-                        modifier = Modifier
-                            .border(
-                                width = 1.dp,
-                                color = Color.LightGray,
-                                shape = RoundedCornerShape(20.dp)
-                            )
-                            .padding(horizontal = 12.dp, vertical = 6.dp),
-                        style = MaterialTheme.typography.body2,
-                        fontWeight = FontWeight.Medium,
-                        textAlign = TextAlign.Center
+                data.forEach { label ->
+                    InventorySuggestionChip(
+                        label = label,
+                        onClick = { onPackageSuggestionClick(label) }
                     )
                 }
             }
@@ -160,69 +375,51 @@ fun OtherPackagesSection(data: List<String>, modifier: Modifier) {
 fun SetupPackageSection(
     packages: List<PackageItem>,
     modifier: Modifier,
-    onAddClicked: () -> Unit = {}
+    onAddPackage: () -> Unit = {},
+    onPackageClick: (PackageItem) -> Unit = {}
 ) {
-    Column {
-        // Header with title + add button
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
         Row(
-            modifier = modifier
-                .fillMaxWidth()
-                .padding(vertical = 8.dp),
+            modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                text = "Setup Package",
+                text = stringResource(R.string.inventory_package_master_title),
                 style = MaterialTheme.typography.h6,
                 fontWeight = FontWeight.Bold
             )
-            Box(
-                modifier = Modifier
-                    .align(Alignment.CenterVertically)
-                    .clickable { onAddClicked() }
-                    .padding(4.dp) // opsional untuk ruang klik
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Add,
-                    contentDescription = "Add Package",
-                    tint = Color(0xFF5B3E9E) // match warna
+            Button(
+                onClick = onAddPackage,
+                shape = RoundedCornerShape(14.dp),
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = MaterialTheme.colors.primary
                 )
+            ) {
+                Text(text = stringResource(R.string.inventory_package_add))
             }
         }
+        Text(
+            text = stringResource(R.string.inventory_package_master_description),
+            style = MaterialTheme.typography.body2,
+            color = MaterialTheme.colors.appMutedContent
+        )
 
-        // Card section
-        Card(
-            backgroundColor = Color(0xFF5B3E9E),
-            shape = RoundedCornerShape(12.dp),
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-        ) {
-            Column(modifier = Modifier.padding(16.dp)) {
-                Text(
-                    text = "Package",
-                    style = MaterialTheme.typography.subtitle1,
-                    fontWeight = FontWeight.Bold,
-                    color = Color.White
-                )
-                Spacer(modifier = Modifier.height(12.dp))
+        if (packages.isEmpty()) {
+            InventoryInfoCard(
+                body = stringResource(R.string.inventory_package_empty_body),
+                modifier = Modifier.fillMaxWidth()
+            )
+        } else {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 packages.forEach { item ->
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 4.dp),
-                        horizontalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        Text(
-                            text = item.name,
-                            color = Color.White,
-                            modifier = Modifier.weight(1f)
-                        )
-                        Text(
-                            text = item.price,
-                            color = Color.White,
-                            textAlign = TextAlign.End
-                        )
-                    }
+                    InventoryPackageRow(
+                        item = item,
+                        onClick = { onPackageClick(item) }
+                    )
                 }
             }
         }
@@ -230,11 +427,217 @@ fun SetupPackageSection(
 }
 
 @Composable
+private fun InventoryPackageRow(
+    item: PackageItem,
+    onClick: () -> Unit = {}
+) {
+    Card(
+        backgroundColor = MaterialTheme.colors.appCardSurface,
+        shape = RoundedCornerShape(20.dp),
+        elevation = 0.dp,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colors.appBorderSoft,
+                shape = RoundedCornerShape(20.dp)
+            )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.Top
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = item.name,
+                    style = MaterialTheme.typography.subtitle1,
+                    color = MaterialTheme.colors.onSurface,
+                    fontWeight = FontWeight.SemiBold
+                )
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = item.displayRate,
+                        style = MaterialTheme.typography.body2,
+                        color = MaterialTheme.colors.appMutedContent,
+                        fontWeight = FontWeight.Medium
+                    )
+
+                    Box(
+                        modifier = Modifier
+                            .border(
+                                width = 1.dp,
+                                color = MaterialTheme.colors.appBorderSoft,
+                                shape = RoundedCornerShape(999.dp)
+                            )
+                            .padding(horizontal = 10.dp, vertical = 4.dp)
+                    ) {
+                        Text(
+                            text = packageDurationText(item),
+                            style = MaterialTheme.typography.caption,
+                            color = MaterialTheme.colors.appMutedContent,
+                            fontWeight = FontWeight.Medium
+                        )
+                    }
+                }
+            }
+
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colors.appMutedContent
+            )
+        }
+    }
+}
+
+@Composable
+private fun InventorySuggestionChip(
+    label: String,
+    onClick: () -> Unit = {}
+) {
+    Box(
+        modifier = Modifier
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colors.appBorderSoft,
+                shape = RoundedCornerShape(20.dp)
+            )
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.body2,
+            color = MaterialTheme.colors.onSurface,
+            fontWeight = FontWeight.Medium,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun InventoryInfoCard(
+    body: String,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        backgroundColor = MaterialTheme.colors.appMutedContainer,
+        shape = RoundedCornerShape(18.dp),
+        elevation = 0.dp,
+        modifier = modifier
+            .border(
+                width = 1.dp,
+                color = MaterialTheme.colors.appBorderSoft,
+                shape = RoundedCornerShape(18.dp)
+            )
+    ) {
+        Text(
+            text = body,
+            style = MaterialTheme.typography.body2,
+            color = MaterialTheme.colors.appMutedContent,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp)
+        )
+    }
+}
+
+@Composable
+private fun packageDurationText(item: PackageItem): String {
+    val duration = item.work.trim()
+    return when {
+        duration.equals("same day", ignoreCase = true) -> {
+            stringResource(R.string.inventory_duration_same_day)
+        }
+
+        duration.endsWith("h", ignoreCase = true) -> {
+            val totalHours = duration.dropLast(1).toIntOrNull()
+            if (totalHours != null) {
+                stringResource(R.string.inventory_duration_hours, totalHours)
+            } else {
+                duration
+            }
+        }
+
+        duration.endsWith("d", ignoreCase = true) -> {
+            val totalDays = duration.dropLast(1).toIntOrNull()
+            if (totalDays != null) {
+                stringResource(R.string.inventory_duration_days, totalDays)
+            } else {
+                duration
+            }
+        }
+
+        duration.isNotBlank() -> duration
+        else -> stringResource(R.string.inventory_duration_unavailable)
+    }
+}
+
+private data class InventoryPackageEditorState(
+    val sheetRowIndex: Int? = null,
+    val name: String = "",
+    val price: String = "",
+    val duration: String = "",
+    val unit: String = ""
+) {
+    val isEditMode: Boolean
+        get() = sheetRowIndex != null
+
+    val isSaveEnabled: Boolean
+        get() = name.trim().isNotBlank() &&
+            price.trim().isNotBlank() &&
+            duration.trim().isNotBlank() &&
+            unit.trim().isNotBlank()
+
+    fun toPackageData(): PackageData {
+        return PackageData(
+            price = price.trim(),
+            name = normalizeInventoryLabel(name),
+            duration = duration.trim(),
+            unit = unit.trim(),
+            sheetRowIndex = sheetRowIndex ?: -1
+        )
+    }
+}
+
+private fun PackageItem.toEditorState(): InventoryPackageEditorState {
+    return InventoryPackageEditorState(
+        sheetRowIndex = sheetRowIndex,
+        name = name,
+        price = price.filter(Char::isDigit),
+        duration = work,
+        unit = unit
+    )
+}
+
+private fun normalizeInventoryLabel(value: String): String {
+    return value.trim().replace(Regex("\\s+"), " ")
+}
+
+@Composable
 @Preview
 fun PreviewInventoryScreen() {
+    val bannerState = rememberInlineAdaptiveBannerAdState("preview_inventory_inline")
+    val scaffoldState = rememberScaffoldState()
     Scaffold(
-        topBar = { DefaultTopAppBar("Inventory") }
+        scaffoldState = scaffoldState,
+        topBar = { DefaultTopAppBar(stringResource(R.string.inventory_title)) },
+        snackbarHost = { SnackbarHost(hostState = scaffoldState.snackbarHostState) }
     ) { padding ->
-        InventoryContent(dummyInventoryUiState, modifier = Modifier.padding(padding))
+        InventoryContent(
+            state = dummyInventoryUiState,
+            bannerState = bannerState,
+            modifier = Modifier.padding(padding)
+        )
     }
 }

--- a/app/src/main/java/com/raylabs/laundryhub/ui/profile/inventory/InventoryViewModel.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/profile/inventory/InventoryViewModel.kt
@@ -3,10 +3,18 @@ package com.raylabs.laundryhub.ui.profile.inventory
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.raylabs.laundryhub.core.domain.model.sheets.PackageData
+import com.raylabs.laundryhub.core.domain.usecase.settings.ObserveSpreadsheetConfigUseCase
+import com.raylabs.laundryhub.core.domain.usecase.sheets.DeletePackageUseCase
 import com.raylabs.laundryhub.core.domain.usecase.sheets.GetOtherPackageUseCase
 import com.raylabs.laundryhub.core.domain.usecase.sheets.ReadPackageUseCase
+import com.raylabs.laundryhub.core.domain.usecase.sheets.SubmitPackageUseCase
+import com.raylabs.laundryhub.core.domain.usecase.sheets.UpdatePackageUseCase
 import com.raylabs.laundryhub.ui.common.util.Resource
 import com.raylabs.laundryhub.ui.common.util.SectionState
+import com.raylabs.laundryhub.ui.common.util.error
+import com.raylabs.laundryhub.ui.common.util.loading
+import com.raylabs.laundryhub.ui.common.util.success
 import com.raylabs.laundryhub.ui.profile.inventory.state.InventoryUiState
 import com.raylabs.laundryhub.ui.profile.inventory.state.toUi
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,33 +24,152 @@ import javax.inject.Inject
 @HiltViewModel
 class InventoryViewModel @Inject constructor(
     private val readPackageUseCase: ReadPackageUseCase,
-    private val getOtherPackageUseCase: GetOtherPackageUseCase
+    private val getOtherPackageUseCase: GetOtherPackageUseCase,
+    private val submitPackageUseCase: SubmitPackageUseCase,
+    private val updatePackageUseCase: UpdatePackageUseCase,
+    private val deletePackageUseCase: DeletePackageUseCase,
+    private val observeSpreadsheetConfigUseCase: ObserveSpreadsheetConfigUseCase
 ) : ViewModel() {
 
     private val _uiState = mutableStateOf(InventoryUiState())
     val uiState: InventoryUiState get() = _uiState.value
 
     init {
+        observeSpreadsheetConfig()
         fetchPackages()
         fetchOtherPackages()
     }
 
+    fun refreshInventory() {
+        fetchPackages()
+        fetchOtherPackages()
+    }
+
+    suspend fun submitPackage(
+        packageData: PackageData,
+        onComplete: suspend () -> Unit,
+        onError: suspend (String) -> Unit = {}
+    ) {
+        _uiState.value = _uiState.value.copy(
+            savePackage = _uiState.value.savePackage.loading()
+        )
+
+        when (val result = submitPackageUseCase(packageData = packageData)) {
+            is Resource.Success -> {
+                _uiState.value = _uiState.value.copy(
+                    savePackage = _uiState.value.savePackage.success(result.data)
+                )
+                refreshInventory()
+                onComplete()
+            }
+
+            is Resource.Error -> {
+                _uiState.value = _uiState.value.copy(
+                    savePackage = _uiState.value.savePackage.error(result.message)
+                )
+                onError(result.message)
+            }
+
+            else -> Unit
+        }
+    }
+
+    suspend fun updatePackage(
+        packageData: PackageData,
+        onComplete: suspend () -> Unit,
+        onError: suspend (String) -> Unit = {}
+    ) {
+        _uiState.value = _uiState.value.copy(
+            savePackage = _uiState.value.savePackage.loading()
+        )
+
+        when (val result = updatePackageUseCase(packageData = packageData)) {
+            is Resource.Success -> {
+                _uiState.value = _uiState.value.copy(
+                    savePackage = _uiState.value.savePackage.success(result.data)
+                )
+                refreshInventory()
+                onComplete()
+            }
+
+            is Resource.Error -> {
+                _uiState.value = _uiState.value.copy(
+                    savePackage = _uiState.value.savePackage.error(result.message)
+                )
+                onError(result.message)
+            }
+
+            else -> Unit
+        }
+    }
+
+    suspend fun deletePackage(
+        sheetRowIndex: Int,
+        onComplete: suspend () -> Unit,
+        onError: suspend (String) -> Unit = {}
+    ) {
+        _uiState.value = _uiState.value.copy(
+            deletePackage = _uiState.value.deletePackage.loading()
+        )
+
+        when (val result = deletePackageUseCase(sheetRowIndex = sheetRowIndex)) {
+            is Resource.Success -> {
+                _uiState.value = _uiState.value.copy(
+                    deletePackage = _uiState.value.deletePackage.success(result.data)
+                )
+                refreshInventory()
+                onComplete()
+            }
+
+            is Resource.Error -> {
+                _uiState.value = _uiState.value.copy(
+                    deletePackage = _uiState.value.deletePackage.error(result.message)
+                )
+                onError(result.message)
+            }
+
+            else -> Unit
+        }
+    }
+
+    private fun observeSpreadsheetConfig() {
+        viewModelScope.launch {
+            observeSpreadsheetConfigUseCase().collect { config ->
+                _uiState.value = _uiState.value.copy(
+                    spreadsheetName = config.spreadsheetName,
+                    spreadsheetId = config.spreadsheetId,
+                    spreadsheetUrl = config.spreadsheetUrl
+                )
+            }
+        }
+    }
 
     private fun fetchPackages() {
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(packages = SectionState(isLoading = true))
+            val current = _uiState.value.packages
+            _uiState.value = _uiState.value.copy(packages = current.loading())
 
             when (val result = readPackageUseCase()) {
                 is Resource.Success -> {
                     val mapped = result.data.toUi()
                     _uiState.value = _uiState.value.copy(
-                        packages = SectionState(data = mapped)
+                        packages = current.success(mapped)
+                    )
+                }
+
+                is Resource.Empty -> {
+                    _uiState.value = _uiState.value.copy(
+                        packages = current.success(emptyList())
                     )
                 }
 
                 is Resource.Error -> {
                     _uiState.value = _uiState.value.copy(
-                        packages = SectionState(errorMessage = result.message)
+                        packages = if (current.data != null) {
+                            current.copy(isLoading = false, errorMessage = result.message)
+                        } else {
+                            SectionState(errorMessage = result.message)
+                        }
                     )
                 }
 
@@ -53,24 +180,29 @@ class InventoryViewModel @Inject constructor(
 
     private fun fetchOtherPackages() {
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(otherPackages = SectionState(isLoading = true))
+            val current = _uiState.value.otherPackages
+            _uiState.value = _uiState.value.copy(otherPackages = current.loading())
 
             when (val result = getOtherPackageUseCase()) {
                 is Resource.Success -> {
                     _uiState.value = _uiState.value.copy(
-                        otherPackages = SectionState(data = result.data)
+                        otherPackages = current.success(result.data)
                     )
                 }
 
                 is Resource.Error -> {
                     _uiState.value = _uiState.value.copy(
-                        otherPackages = SectionState(errorMessage = result.message)
+                        otherPackages = if (current.data != null) {
+                            current.copy(isLoading = false, errorMessage = result.message)
+                        } else {
+                            SectionState(errorMessage = result.message)
+                        }
                     )
                 }
 
                 is Resource.Empty -> {
                     _uiState.value = _uiState.value.copy(
-                        otherPackages = SectionState(errorMessage = "Tidak ada paket lain.")
+                        otherPackages = current.success(emptyList())
                     )
                 }
 

--- a/app/src/main/java/com/raylabs/laundryhub/ui/profile/inventory/state/InventoryUiState.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/profile/inventory/state/InventoryUiState.kt
@@ -3,6 +3,11 @@ package com.raylabs.laundryhub.ui.profile.inventory.state
 import com.raylabs.laundryhub.ui.common.util.SectionState
 
 data class InventoryUiState(
+    val spreadsheetName: String? = null,
+    val spreadsheetId: String? = null,
+    val spreadsheetUrl: String? = null,
     val packages: SectionState<List<PackageItem>> = SectionState(),
-    val otherPackages: SectionState<List<String>> = SectionState()
+    val otherPackages: SectionState<List<String>> = SectionState(),
+    val savePackage: SectionState<Boolean> = SectionState(),
+    val deletePackage: SectionState<Boolean> = SectionState()
 )

--- a/app/src/main/java/com/raylabs/laundryhub/ui/profile/inventory/state/PackageItem.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/profile/inventory/state/PackageItem.kt
@@ -1,15 +1,18 @@
 package com.raylabs.laundryhub.ui.profile.inventory.state
 
 import com.raylabs.laundryhub.core.domain.model.sheets.PackageData
+import java.text.NumberFormat
+import java.util.Locale
 
 data class PackageItem(
     val name: String,
     val price: String,
     val work: String,
     val unit: String = "",
+    val sheetRowIndex: Int = -1,
 ) {
     val displayPrice: String
-        get() = "$price,-"
+        get() = formatPackagePrice(price)
 
     val displayRate: String
         get() = buildString {
@@ -27,7 +30,26 @@ fun List<PackageData>.toUi(): List<PackageItem> {
             name = it.name,
             price = it.price,
             work = it.duration,
-            unit = it.unit
+            unit = it.unit,
+            sheetRowIndex = it.sheetRowIndex
         )
     }
+}
+
+private fun formatPackagePrice(rawPrice: String): String {
+    val trimmed = rawPrice.trim()
+    if (trimmed.isBlank()) return ""
+
+    val normalizedDigits = trimmed.filter(Char::isDigit)
+    val numericValue = normalizedDigits.toLongOrNull()
+    if (numericValue != null) {
+        val locale = Locale.Builder()
+            .setLanguage("id")
+            .setRegion("ID")
+            .build()
+        val formatted = NumberFormat.getInstance(locale).format(numericValue)
+        return "Rp$formatted"
+    }
+
+    return trimmed
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,10 +130,43 @@
     <string name="account_section_title">Account</string>
     <string name="inventory_title">Inventory</string>
     <string name="inventory_description">Setup order package</string>
+    <string name="inventory_package_master_title">Package master</string>
+    <string name="inventory_package_master_description">Used in new orders. Tap a row to edit or delete.</string>
+    <string name="inventory_package_empty_body">Add your first package to use it in new orders.</string>
+    <string name="inventory_package_add">Add package</string>
+    <string name="inventory_package_adding">Adding...</string>
+    <string name="inventory_package_action_edit_title">Edit package</string>
+    <string name="inventory_package_action_delete_title">Delete package</string>
+    <string name="inventory_package_delete_confirmation_title">Delete this package?</string>
+    <string name="inventory_package_delete_confirmation_message">%1$s will be removed from your package master.</string>
+    <string name="inventory_package_delete_point_permanent">This change goes straight to the connected spreadsheet.</string>
+    <string name="inventory_package_delete_point_orders">Past orders keep their saved package names.</string>
+    <string name="inventory_package_editor_add_title">Add package</string>
+    <string name="inventory_package_editor_update_title">Update package</string>
+    <string name="inventory_package_field_name">Package name</string>
+    <string name="inventory_package_field_price">Price per unit</string>
+    <string name="inventory_package_field_duration">Duration</string>
+    <string name="inventory_package_duration_hint">Example: 6h, 1d, 3d, or Same day.</string>
+    <string name="inventory_package_field_unit">Unit</string>
+    <string name="inventory_package_add_success">%1$s added to the package master.</string>
+    <string name="inventory_package_add_failed">Unable to add package right now.</string>
+    <string name="inventory_package_update_success">%1$s updated successfully.</string>
+    <string name="inventory_package_update_failed">Unable to update package right now.</string>
+    <string name="inventory_package_delete_success">%1$s deleted from the package master.</string>
+    <string name="inventory_package_delete_failed">Unable to delete package right now.</string>
+    <string name="inventory_unmapped_title">Unregistered package names</string>
+    <string name="inventory_unmapped_description">Seen in transaction remarks but not in your master list yet.</string>
+    <string name="inventory_unmapped_tap_hint">Tap a name to prefill a new package.</string>
+    <string name="inventory_unmapped_empty_body">No unregistered package names found.</string>
+    <string name="inventory_duration_same_day">Same day</string>
+    <string name="inventory_duration_hours">%1$d Hours</string>
+    <string name="inventory_duration_days">%1$d Days</string>
+    <string name="inventory_duration_unavailable">Duration not set</string>
     <string name="app_version">App version</string>
     <string name="sign_out">Sign Out</string>
     <string name="spreadsheet_id_label">ID: %1$s</string>
     <string name="spreadsheet_status_not_connected">Not connected</string>
+    <string name="currency_prefix_rupiah" translatable="false">Rp</string>
     <string name="ad_preview_label" translatable="false">Ad space</string>
 
     <string name="reminder_section_title">Reminder &amp; Cross-check</string>

--- a/app/src/test/java/com/raylabs/laundryhub/core/data/repository/GoogleSheetRepositoryImplTest.kt
+++ b/app/src/test/java/com/raylabs/laundryhub/core/data/repository/GoogleSheetRepositoryImplTest.kt
@@ -8,6 +8,7 @@ import com.google.api.services.sheets.v4.model.ValueRange
 import com.raylabs.laundryhub.core.data.service.GoogleSheetService
 import com.raylabs.laundryhub.core.domain.model.sheets.FILTER
 import com.raylabs.laundryhub.core.domain.model.sheets.OrderData
+import com.raylabs.laundryhub.core.domain.model.sheets.PackageData
 import com.raylabs.laundryhub.core.domain.repository.SpreadsheetIdProvider
 import com.raylabs.laundryhub.ui.common.util.Resource
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -351,6 +352,8 @@ class GoogleSheetRepositoryImplTest {
         assertEquals("Regular", data[0].name)
         assertEquals("5000", data[0].price)
         assertEquals("Express", data[1].name)
+        assertEquals(2, data[0].sheetRowIndex)
+        assertEquals(3, data[1].sheetRowIndex)
     }
 
     @Test
@@ -389,6 +392,107 @@ class GoogleSheetRepositoryImplTest {
         assertTrue(result is Resource.Success)
         val data = (result as Resource.Success).data
         assertEquals(listOf("Note A", "Note B"), data)
+    }
+
+    @Test
+    fun `addPackage appends package row to notes sheet`() = runTest {
+        val sheets = mock<com.google.api.services.sheets.v4.Sheets>()
+        val spreadsheets = mock<com.google.api.services.sheets.v4.Sheets.Spreadsheets>()
+        val valuesApi = mock<com.google.api.services.sheets.v4.Sheets.Spreadsheets.Values>()
+        val append = mock<com.google.api.services.sheets.v4.Sheets.Spreadsheets.Values.Append>()
+
+        whenever(googleSheetService.getSheetsService()).thenReturn(sheets)
+        whenever(sheets.spreadsheets()).thenReturn(spreadsheets)
+        whenever(spreadsheets.values()).thenReturn(valuesApi)
+        whenever(valuesApi.append(any(), any(), any())).thenReturn(append)
+        whenever(append.setValueInputOption(any())).thenReturn(append)
+        whenever(append.execute()).thenReturn(mock())
+
+        val result = repo.addPackage(
+            PackageData(price = "5000", name = "Regular", duration = "3d", unit = "kg")
+        )
+
+        assertTrue(result is Resource.Success)
+        verify(valuesApi).append(
+            eq(TEST_SPREADSHEET_ID),
+            eq("notes!A:D"),
+            argThat { range ->
+                range.getValues() == listOf(listOf("5000", "Regular", "3d", "kg"))
+            }
+        )
+    }
+
+    @Test
+    fun `updatePackage updates targeted notes row`() = runTest {
+        val sheets = mock<com.google.api.services.sheets.v4.Sheets>()
+        val spreadsheets = mock<com.google.api.services.sheets.v4.Sheets.Spreadsheets>()
+        val valuesApi = mock<com.google.api.services.sheets.v4.Sheets.Spreadsheets.Values>()
+        val update = mock<com.google.api.services.sheets.v4.Sheets.Spreadsheets.Values.Update>()
+
+        whenever(googleSheetService.getSheetsService()).thenReturn(sheets)
+        whenever(sheets.spreadsheets()).thenReturn(spreadsheets)
+        whenever(spreadsheets.values()).thenReturn(valuesApi)
+        whenever(valuesApi.update(any(), any(), any())).thenReturn(update)
+        whenever(update.setValueInputOption(any())).thenReturn(update)
+        whenever(update.execute()).thenReturn(mock())
+
+        val result = repo.updatePackage(
+            PackageData(
+                price = "8000",
+                name = "Express",
+                duration = "1d",
+                unit = "kg",
+                sheetRowIndex = 4
+            )
+        )
+
+        assertTrue(result is Resource.Success)
+        verify(valuesApi).update(
+            eq(TEST_SPREADSHEET_ID),
+            eq("notes!A4:D"),
+            argThat { range ->
+                range.getValues() == listOf(listOf("8000", "Express", "1d", "kg"))
+            }
+        )
+    }
+
+    @Test
+    fun `deletePackage removes targeted notes row via batch update`() = runTest {
+        val sheets = mock<com.google.api.services.sheets.v4.Sheets>()
+        val spreadsheets = mock<com.google.api.services.sheets.v4.Sheets.Spreadsheets>()
+        val getSpreadsheet = mock<com.google.api.services.sheets.v4.Sheets.Spreadsheets.Get>()
+        val batchUpdate = mock<com.google.api.services.sheets.v4.Sheets.Spreadsheets.BatchUpdate>()
+
+        whenever(googleSheetService.getSheetsService()).thenReturn(sheets)
+        whenever(sheets.spreadsheets()).thenReturn(spreadsheets)
+        whenever(spreadsheets.get(any())).thenReturn(getSpreadsheet)
+        whenever(spreadsheets.batchUpdate(any(), any())).thenReturn(batchUpdate)
+        whenever(batchUpdate.execute()).thenReturn(mock())
+        whenever(getSpreadsheet.execute()).thenReturn(
+            Spreadsheet().setSheets(
+                listOf(
+                    Sheet().setProperties(
+                        SheetProperties()
+                            .setTitle("notes")
+                            .setSheetId(13)
+                    )
+                )
+            )
+        )
+
+        val result = repo.deletePackage(sheetRowIndex = 4)
+
+        assertTrue(result is Resource.Success)
+        verify(spreadsheets).batchUpdate(
+            eq(TEST_SPREADSHEET_ID),
+            argThat { request ->
+                val range = request.requests.single().deleteDimension.range
+                range.sheetId == 13 &&
+                    range.dimension == "ROWS" &&
+                    range.startIndex == 3 &&
+                    range.endIndex == 4
+            }
+        )
     }
 
     @Test

--- a/app/src/test/java/com/raylabs/laundryhub/core/domain/model/sheets/PackageDataExtTest.kt
+++ b/app/src/test/java/com/raylabs/laundryhub/core/domain/model/sheets/PackageDataExtTest.kt
@@ -14,12 +14,13 @@ class PackageDataExtTest {
             "unit" to "kg"
         )
 
-        val result = map.toPackageData()
+        val result = map.toPackageData(sheetRowIndex = 5)
 
         assertEquals("5000", result.price)
         assertEquals("Reguler", result.name)
         assertEquals("3d", result.duration)
         assertEquals("kg", result.unit)
+        assertEquals(5, result.sheetRowIndex)
     }
 
     @Test
@@ -47,5 +48,19 @@ class PackageDataExtTest {
         assertEquals("", result.name)
         assertEquals("", result.duration)
         assertEquals("", result.unit)
+    }
+
+    @Test
+    fun `toSheetValues returns spreadsheet row format`() {
+        val data = PackageData(
+            price = "5000",
+            name = "Reguler",
+            duration = "3d",
+            unit = "kg"
+        )
+
+        val result = data.toSheetValues()
+
+        assertEquals(listOf(listOf("5000", "Reguler", "3d", "kg")), result)
     }
 }

--- a/app/src/test/java/com/raylabs/laundryhub/core/domain/usecase/sheets/GetOtherPackageUseCaseTest.kt
+++ b/app/src/test/java/com/raylabs/laundryhub/core/domain/usecase/sheets/GetOtherPackageUseCaseTest.kt
@@ -64,5 +64,24 @@ class GetOtherPackageUseCaseTest {
         val data = (result as Resource.Success).data
         assertEquals(listOf("C", "D"), data)
     }
-}
 
+    @Test
+    fun `filters package names case insensitively and normalizes spacing`() = runTest {
+        whenever(repository.readOtherPackage()).thenReturn(
+            Resource.Success(listOf("Express - 6H", " express   - 6h ", "Regular", "regular cuci"))
+        )
+        whenever(repository.readPackageData()).thenReturn(
+            Resource.Success(
+                listOf(
+                    PackageData("1", "express - 6h", "", ""),
+                    PackageData("2", "Regular", "", "")
+                )
+            )
+        )
+
+        val result = useCase.invoke()
+
+        assertTrue(result is Resource.Success)
+        assertEquals(listOf("regular cuci"), (result as Resource.Success).data)
+    }
+}

--- a/app/src/test/java/com/raylabs/laundryhub/core/domain/usecase/sheets/PackageCrudUseCasesTest.kt
+++ b/app/src/test/java/com/raylabs/laundryhub/core/domain/usecase/sheets/PackageCrudUseCasesTest.kt
@@ -1,0 +1,108 @@
+package com.raylabs.laundryhub.core.domain.usecase.sheets
+
+import com.raylabs.laundryhub.core.domain.model.sheets.PackageData
+import com.raylabs.laundryhub.core.domain.repository.GoogleSheetRepository
+import com.raylabs.laundryhub.ui.common.util.Resource
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PackageCrudUseCasesTest {
+
+    private lateinit var repository: GoogleSheetRepository
+    private lateinit var submitPackageUseCase: SubmitPackageUseCase
+    private lateinit var updatePackageUseCase: UpdatePackageUseCase
+    private lateinit var deletePackageUseCase: DeletePackageUseCase
+
+    @Before
+    fun setUp() {
+        repository = mock()
+        submitPackageUseCase = SubmitPackageUseCase(repository)
+        updatePackageUseCase = UpdatePackageUseCase(repository)
+        deletePackageUseCase = DeletePackageUseCase(repository)
+    }
+
+    @Test
+    fun `submitPackage returns success when repository addPackage succeeds`() = runTest {
+        val packageData = PackageData(price = "5000", name = "Regular", duration = "3d", unit = "kg")
+        whenever(repository.readPackageData()).thenReturn(Resource.Success(emptyList()))
+        whenever(repository.addPackage(packageData)).thenReturn(Resource.Success(true))
+
+        val result = submitPackageUseCase(packageData = packageData)
+
+        assertTrue(result is Resource.Success)
+        assertEquals(true, (result as Resource.Success).data)
+    }
+
+    @Test
+    fun `submitPackage rejects duplicate package name`() = runTest {
+        val packageData = PackageData(price = "5000", name = "Regular", duration = "3d", unit = "kg")
+        whenever(repository.readPackageData()).thenReturn(
+            Resource.Success(
+                listOf(PackageData(price = "8000", name = " regular ", duration = "1d", unit = "kg", sheetRowIndex = 2))
+            )
+        )
+
+        val result = submitPackageUseCase(packageData = packageData)
+
+        assertTrue(result is Resource.Error)
+        assertEquals("Package name already exists in the master list.", (result as Resource.Error).message)
+    }
+
+    @Test
+    fun `updatePackage returns success when repository updatePackage succeeds`() = runTest {
+        val packageData = PackageData(
+            price = "8000",
+            name = "Express",
+            duration = "1d",
+            unit = "kg",
+            sheetRowIndex = 4
+        )
+        whenever(repository.readPackageData()).thenReturn(Resource.Success(listOf(packageData)))
+        whenever(repository.updatePackage(packageData)).thenReturn(Resource.Success(true))
+
+        val result = updatePackageUseCase(packageData = packageData)
+
+        assertTrue(result is Resource.Success)
+        assertEquals(true, (result as Resource.Success).data)
+    }
+
+    @Test
+    fun `updatePackage rejects missing row index`() = runTest {
+        val packageData = PackageData(
+            price = "8000",
+            name = "Express",
+            duration = "1d",
+            unit = "kg"
+        )
+
+        val result = updatePackageUseCase(packageData = packageData)
+
+        assertTrue(result is Resource.Error)
+        assertEquals("Package row not found.", (result as Resource.Error).message)
+    }
+
+    @Test
+    fun `deletePackage returns success when repository deletePackage succeeds`() = runTest {
+        whenever(repository.deletePackage(4)).thenReturn(Resource.Success(true))
+
+        val result = deletePackageUseCase(sheetRowIndex = 4)
+
+        assertTrue(result is Resource.Success)
+        assertEquals(true, (result as Resource.Success).data)
+    }
+
+    @Test
+    fun `deletePackage rejects invalid row index`() = runTest {
+        val result = deletePackageUseCase(sheetRowIndex = -1)
+
+        assertTrue(result is Resource.Error)
+        assertEquals("Package row not found.", (result as Resource.Error).message)
+    }
+}

--- a/app/src/test/java/com/raylabs/laundryhub/ui/inventory/InventoryViewModelTest.kt
+++ b/app/src/test/java/com/raylabs/laundryhub/ui/inventory/InventoryViewModelTest.kt
@@ -1,13 +1,19 @@
 package com.raylabs.laundryhub.ui.inventory
 
+import com.raylabs.laundryhub.core.domain.model.settings.SpreadsheetConfig
 import com.raylabs.laundryhub.core.domain.model.sheets.PackageData
+import com.raylabs.laundryhub.core.domain.usecase.settings.ObserveSpreadsheetConfigUseCase
+import com.raylabs.laundryhub.core.domain.usecase.sheets.DeletePackageUseCase
 import com.raylabs.laundryhub.core.domain.usecase.sheets.GetOtherPackageUseCase
 import com.raylabs.laundryhub.core.domain.usecase.sheets.ReadPackageUseCase
+import com.raylabs.laundryhub.core.domain.usecase.sheets.SubmitPackageUseCase
+import com.raylabs.laundryhub.core.domain.usecase.sheets.UpdatePackageUseCase
 import com.raylabs.laundryhub.ui.common.dummy.inventory.dummyInventoryUiState
 import com.raylabs.laundryhub.ui.common.util.Resource
 import com.raylabs.laundryhub.ui.profile.inventory.InventoryViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -17,9 +23,12 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.atLeast
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -28,6 +37,10 @@ class InventoryViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
     private val mockReadPackageUseCase: ReadPackageUseCase = mock()
     private val mockGetOtherPackageUseCase: GetOtherPackageUseCase = mock()
+    private val mockSubmitPackageUseCase: SubmitPackageUseCase = mock()
+    private val mockUpdatePackageUseCase: UpdatePackageUseCase = mock()
+    private val mockDeletePackageUseCase: DeletePackageUseCase = mock()
+    private val mockObserveSpreadsheetConfigUseCase: ObserveSpreadsheetConfigUseCase = mock()
 
     @Before
     fun setUp() {
@@ -45,11 +58,12 @@ class InventoryViewModelTest {
             PackageData(name = it.name, price = it.price, duration = it.work, unit = "")
         }
         val dummyOtherPackages = dummyInventoryUiState.otherPackages.data!!
+        stubSpreadsheetConfig()
 
         whenever(mockReadPackageUseCase.invoke()).thenReturn(Resource.Success(dummyPackages))
         whenever(mockGetOtherPackageUseCase.invoke()).thenReturn(Resource.Success(dummyOtherPackages))
 
-        val vm = InventoryViewModel(mockReadPackageUseCase, mockGetOtherPackageUseCase)
+        val vm = createViewModel()
         testDispatcher.scheduler.advanceUntilIdle()
 
         val state = vm.uiState
@@ -61,13 +75,16 @@ class InventoryViewModelTest {
         assertEquals(dummyInventoryUiState.otherPackages.data!!.first(), state.otherPackages.data!!.first())
         assertFalse(state.packages.isLoading)
         assertFalse(state.otherPackages.isLoading)
+        assertEquals("LaundryHub Spreadsheet", state.spreadsheetName)
+        assertEquals("sheet-123", state.spreadsheetId)
     }
 
     @Test
     fun `fetchPackages handles error`() = runTest {
+        stubSpreadsheetConfig(empty = true)
         whenever(mockReadPackageUseCase.invoke()).thenReturn(Resource.Error("Gagal"))
         whenever(mockGetOtherPackageUseCase.invoke()).thenReturn(Resource.Success(emptyList()))
-        val vm = InventoryViewModel(mockReadPackageUseCase, mockGetOtherPackageUseCase)
+        val vm = createViewModel()
         testDispatcher.scheduler.advanceUntilIdle()
 
         val state = vm.uiState
@@ -77,25 +94,117 @@ class InventoryViewModelTest {
 
     @Test
     fun `fetchOtherPackages handles error and empty`() = runTest {
+        stubSpreadsheetConfig(empty = true)
         whenever(mockReadPackageUseCase.invoke()).thenReturn(Resource.Success(emptyList()))
         whenever(mockGetOtherPackageUseCase.invoke()).thenReturn(Resource.Error("API error"))
-        val vm = InventoryViewModel(mockReadPackageUseCase, mockGetOtherPackageUseCase)
+        val vm = createViewModel()
         testDispatcher.scheduler.advanceUntilIdle()
 
         val state = vm.uiState
         assertEquals("API error", state.otherPackages.errorMessage)
         assertNull(state.otherPackages.data)
 
-        // Test Empty resource
         whenever(mockGetOtherPackageUseCase.invoke()).thenReturn(Resource.Empty)
-        vm.apply {
-            // jalankan lagi fetchOtherPackages untuk trigger state
-            val method = this::class.java.getDeclaredMethod("fetchOtherPackages")
-            method.isAccessible = true
-            method.invoke(this)
-        }
+        vm.refreshInventory()
         testDispatcher.scheduler.advanceUntilIdle()
+
         val stateAfterEmpty = vm.uiState
-        assertEquals("Tidak ada paket lain.", stateAfterEmpty.otherPackages.errorMessage)
+        assertNotNull(stateAfterEmpty.otherPackages.data)
+        assertTrue(stateAfterEmpty.otherPackages.data!!.isEmpty())
+        assertNull(stateAfterEmpty.otherPackages.errorMessage)
+    }
+
+    @Test
+    fun `refreshInventory re-fetches packages and otherPackages`() = runTest {
+        stubSpreadsheetConfig(empty = true)
+        whenever(mockReadPackageUseCase.invoke()).thenReturn(Resource.Success(emptyList()))
+        whenever(mockGetOtherPackageUseCase.invoke()).thenReturn(Resource.Success(emptyList()))
+
+        val vm = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.refreshInventory()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(mockReadPackageUseCase, atLeast(2)).invoke()
+        verify(mockGetOtherPackageUseCase, atLeast(2)).invoke()
+    }
+
+    @Test
+    fun `submitPackage updates save state and refreshes inventory`() = runTest {
+        stubSpreadsheetConfig(empty = true)
+        whenever(mockReadPackageUseCase.invoke()).thenReturn(Resource.Success(emptyList()))
+        whenever(mockGetOtherPackageUseCase.invoke()).thenReturn(Resource.Success(emptyList()))
+        whenever(
+            mockSubmitPackageUseCase.invoke(
+                onRetry = org.mockito.kotlin.anyOrNull(),
+                packageData = org.mockito.kotlin.any()
+            )
+        )
+            .thenReturn(Resource.Success(true))
+
+        val vm = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.submitPackage(
+            packageData = PackageData(price = "5000", name = "Regular", duration = "3d", unit = "kg"),
+            onComplete = {},
+            onError = {}
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(true, vm.uiState.savePackage.data)
+        verify(mockReadPackageUseCase, atLeast(2)).invoke()
+        verify(mockGetOtherPackageUseCase, atLeast(2)).invoke()
+    }
+
+    @Test
+    fun `deletePackage updates delete state and refreshes inventory`() = runTest {
+        stubSpreadsheetConfig(empty = true)
+        whenever(mockReadPackageUseCase.invoke()).thenReturn(Resource.Success(emptyList()))
+        whenever(mockGetOtherPackageUseCase.invoke()).thenReturn(Resource.Success(emptyList()))
+        whenever(mockDeletePackageUseCase.invoke(onRetry = null, sheetRowIndex = 4))
+            .thenReturn(Resource.Success(true))
+
+        val vm = createViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.deletePackage(
+            sheetRowIndex = 4,
+            onComplete = {},
+            onError = {}
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(true, vm.uiState.deletePackage.data)
+        verify(mockReadPackageUseCase, atLeast(2)).invoke()
+        verify(mockGetOtherPackageUseCase, atLeast(2)).invoke()
+    }
+
+    private fun stubSpreadsheetConfig(empty: Boolean = false) {
+        whenever(mockObserveSpreadsheetConfigUseCase.invoke()).thenReturn(
+            flowOf(
+                if (empty) {
+                    SpreadsheetConfig()
+                } else {
+                    SpreadsheetConfig(
+                        spreadsheetId = "sheet-123",
+                        spreadsheetName = "LaundryHub Spreadsheet",
+                        spreadsheetUrl = "https://docs.google.com/spreadsheets/d/sheet-123/edit"
+                    )
+                }
+            )
+        )
+    }
+
+    private fun createViewModel(): InventoryViewModel {
+        return InventoryViewModel(
+            mockReadPackageUseCase,
+            mockGetOtherPackageUseCase,
+            mockSubmitPackageUseCase,
+            mockUpdatePackageUseCase,
+            mockDeletePackageUseCase,
+            mockObserveSpreadsheetConfigUseCase
+        )
     }
 }

--- a/app/src/test/java/com/raylabs/laundryhub/ui/inventory/state/InventoryUiStateTest.kt
+++ b/app/src/test/java/com/raylabs/laundryhub/ui/inventory/state/InventoryUiStateTest.kt
@@ -18,8 +18,12 @@ class InventoryUiStateTest {
         assertNull(state.otherPackages.data)
         assertNull(state.packages.errorMessage)
         assertNull(state.otherPackages.errorMessage)
+        assertNull(state.savePackage.data)
+        assertNull(state.deletePackage.data)
         assertFalse(state.packages.isLoading)
         assertFalse(state.otherPackages.isLoading)
+        assertFalse(state.savePackage.isLoading)
+        assertFalse(state.deletePackage.isLoading)
     }
 
     @Test

--- a/app/src/test/java/com/raylabs/laundryhub/ui/inventory/state/PackageItemTest.kt
+++ b/app/src/test/java/com/raylabs/laundryhub/ui/inventory/state/PackageItemTest.kt
@@ -11,18 +11,24 @@ class PackageItemTest {
     @Test
     fun `displayPrice returns formatted price`() {
         val item = PackageItem(name = "Express", price = "10000", work = "6h")
-        assertEquals("10000,-", item.displayPrice)
+        assertEquals("Rp10.000", item.displayPrice)
     }
 
     @Test
     fun `displayRate appends unit when available`() {
         val item = PackageItem(name = "Express", price = "10000", work = "6h", unit = "kg")
-        assertEquals("10000,-/kg", item.displayRate)
+        assertEquals("Rp10.000/kg", item.displayRate)
+    }
+
+    @Test
+    fun `displayPrice keeps formatted rupiah stable when raw input already contains prefix`() {
+        val item = PackageItem(name = "Express", price = "Rp 10.000", work = "6h", unit = "kg")
+        assertEquals("Rp10.000", item.displayPrice)
     }
 
     @Test
     fun `toUi maps PackageData to PackageItem correctly`() {
-        val data = PackageData(name = "Reguler", price = "5000", duration = "3d", unit = "kg")
+        val data = PackageData(name = "Reguler", price = "5000", duration = "3d", unit = "kg", sheetRowIndex = 4)
         val list = listOf(data).toUi()
         assertEquals(1, list.size)
         val item = list[0]
@@ -30,6 +36,7 @@ class PackageItemTest {
         assertEquals("5000", item.price)
         assertEquals("3d", item.work)
         assertEquals("kg", item.unit)
+        assertEquals(4, item.sheetRowIndex)
     }
 
     @Test

--- a/docs/ui/order/README.md
+++ b/docs/ui/order/README.md
@@ -29,12 +29,14 @@ The current order flow now:
 - shows `Payment Method` as horizontally scrollable choice chips inside the form
 - makes selected payment chips use higher-contrast text so the active state is easier to read
 - keeps the whole interaction in one form surface without opening a second popup or pseudo-page
+- reflects package master updates coming from Inventory package CRUD, because order selection still reads from the shared spreadsheet-backed package list
 
 ## Important Decisions
 
 - platform popup dropdowns are no longer the preferred pattern for order form selection because the dark-mode result was inconsistent across devices
 - `Package` uses cards instead of chips because the package choice needs more context than a short label
 - package cards now preserve the package `unit` from sheet data so the rate can be shown as `price/unit` inside the selection UI
+- Inventory package CRUD intentionally affects future order selection only; past order history still keeps the package text that was already saved at the time
 - `Payment Method` uses chips because the option count is small and the labels are short enough to scan quickly
 - shared selection building blocks now live in `ui/component/SelectionControls.kt`
 

--- a/docs/ui/profile/README.md
+++ b/docs/ui/profile/README.md
@@ -1,7 +1,7 @@
 # Profile UI
 
 Status: active living brief
-Last updated: 2026-04-04
+Last updated: 2026-04-19
 Primary area: `ui/profile`
 
 ## Goal
@@ -55,19 +55,91 @@ Important limitation:
 - secondary spreadsheet actions use a transparent outlined button style
 - the spreadsheet secondary action label is shortened to avoid awkward wrapping on narrow phones
 
+### Inventory
+
+Profile still routes to a dedicated Inventory screen, and that screen now supports real package management against the spreadsheet-backed package master.
+
+Inventory can now:
+
+- pull to refresh package data from the connected spreadsheet
+- show package master rows in a scan-first layout with name, rate (`price/unit`), and duration
+- normalize package rate display more consistently from spreadsheet values such as `10000` or `Rp 10.000`
+- show real snackbar feedback when package reads fail
+- add a new package from Inventory and sync it back to the `notes` sheet
+- update an existing package from Inventory without opening a separate spreadsheet flow
+- delete an existing package with an in-screen confirmation sheet
+- open package actions from the package row itself instead of scattering edit/delete buttons inline
+- treat empty `other packages` as a normal empty state instead of an error
+- highlight package names seen in transactions that are not part of the package master yet
+- prefill a new package form by tapping an unmatched package name from the audit section
+- show Inventory as a dedicated route with an explicit back action instead of relying only on system back
+- keep Inventory copy intentionally shorter so each section stays focused on one main action instead of stacking helper text
+- keep generous top and bottom content breathing room so the first and last content blocks do not feel cramped against the app bar or screen edge
+
+Important limitation:
+
+- package rename or delete only changes the current master list for future order selection
+- existing history is intentionally not migrated because past orders already store package names as text
+- package writes target the current spreadsheet row identity, not historical transaction cleanup
+
+## Inventory One-Go Outcome
+
+The one-go Inventory pass was completed on 2026-04-19 with the current spreadsheet architecture still intact.
+
+What shipped:
+
+- package CRUD now writes to the `notes` sheet instead of stopping at a read-only audit surface
+- add/edit/delete flows stay inside the current screen using in-screen action and confirmation sheets
+- package rows are identified by spreadsheet row index when editing or deleting, so writes target the selected row instead of guessing by package name
+- unmatched package names can open a prefilled add-package sheet, which makes the maintenance loop shorter when staff start typing new package names in remarks
+- order package selection still reads from the same package master model, so new orders see the latest package list after Inventory changes
+- package name normalization is still applied when comparing `other packages`, which keeps false positives lower even while CRUD is available
+
+Safety decisions that were kept:
+
+- spreadsheet schema was not changed
+- historical orders are not migrated on package rename/delete
+- package management remains spreadsheet-backed; there is still no second local package source of truth
+- the latest UX cleanup intentionally removed several helper paragraphs in favor of clearer section titles, row affordances, and bottom-sheet follow-up actions
+
+Read first if Inventory package management needs follow-up:
+
+- `app/src/main/java/com/raylabs/laundryhub/ui/profile/inventory/InventoryScreenView.kt`
+- `app/src/main/java/com/raylabs/laundryhub/ui/profile/inventory/InventoryViewModel.kt`
+- `app/src/main/java/com/raylabs/laundryhub/ui/profile/inventory/state/PackageItem.kt`
+- `app/src/main/java/com/raylabs/laundryhub/ui/component/InventoryPackageSheets.kt`
+- `app/src/main/java/com/raylabs/laundryhub/core/domain/repository/GoogleSheetRepository.kt`
+- `app/src/main/java/com/raylabs/laundryhub/core/data/repository/GoogleSheetRepositoryImpl.kt`
+- `app/src/main/java/com/raylabs/laundryhub/core/domain/usecase/sheets/ReadPackageUseCase.kt`
+- `app/src/main/java/com/raylabs/laundryhub/core/domain/usecase/sheets/GetOtherPackageUseCase.kt`
+- `app/src/main/java/com/raylabs/laundryhub/core/domain/usecase/sheets/SubmitPackageUseCase.kt`
+- `app/src/main/java/com/raylabs/laundryhub/core/domain/usecase/sheets/UpdatePackageUseCase.kt`
+- `app/src/main/java/com/raylabs/laundryhub/core/domain/usecase/sheets/DeletePackageUseCase.kt`
+- `app/src/main/java/com/raylabs/laundryhub/ui/order/OrderBottomSheetScreen.kt`
+- `app/src/main/res/values/strings.xml`
+
 ## Important Decisions
 
 - no separate `Disconnect Spreadsheet` action yet because the current next state is the same as `Change Spreadsheet`
 - Profile should stay utility-first, so copy is intentionally brief
 - spreadsheet confirmation now uses a bottom-sheet pattern instead of a generic dialog so it feels more like part of the app flow
 - custom confirmation sheets should keep the current Profile screen visible behind the scrim instead of switching to a blank dialog-style background
+- inventory package CRUD is now supported directly against the spreadsheet package master, so the screen no longer needs a fake read-only stance
+- unmatched package names should be framed as a maintenance hint for the package master, not as a fatal error state
+- package edit/delete targets the current spreadsheet row identity instead of relying on package-name matching alone
 
 ## Verification
 
 These commands passed across the profile updates:
 
 ```bash
+./gradlew testDebugUnitTest --tests com.raylabs.laundryhub.ui.inventory.InventoryViewModelTest --no-daemon
+./gradlew testDebugUnitTest --tests com.raylabs.laundryhub.ui.inventory.state.PackageItemTest --no-daemon
+./gradlew testDebugUnitTest --tests com.raylabs.laundryhub.core.domain.usecase.sheets.GetOtherPackageUseCaseTest --no-daemon
+./gradlew testDebugUnitTest --tests com.raylabs.laundryhub.core.domain.usecase.sheets.PackageCrudUseCasesTest --no-daemon
+./gradlew testDebugUnitTest --tests com.raylabs.laundryhub.core.data.repository.GoogleSheetRepositoryImplTest --no-daemon
 ./gradlew assembleDebug
+./gradlew assembleDebug --no-daemon
 ./gradlew testDebugUnitTest
 ```
 
@@ -75,3 +147,5 @@ These commands passed across the profile updates:
 
 - consider adding `Open Spreadsheet` or `Copy Spreadsheet ID` only if they solve a real user need
 - if Profile grows further, consider collapsible sections before adding more descriptive text
+- if package names become messy in real usage, consider adding a lightweight package-alias policy before changing how historical orders are interpreted
+- if spreadsheet edits happen concurrently outside the app more often, consider an extra stale-row guard before package update/delete writes


### PR DESCRIPTION
This commit implements full CRUD (Create, Read, Update, Delete) capabilities for the order package system, moving from a read-only audit view to a managed package master. The system remains spreadsheet-backed, targeting specific row indices for precise updates and deletions.

### Features
- **Package Editor**: Added `InventoryPackageEditorSheet` to create or update packages with fields for name, price, duration, and unit.
- **Action & Confirmation Sheets**: Introduced `InventoryPackageActionSheet` for quick access to edit/delete flows and `InventoryPackageDeleteConfirmationSheet` to prevent accidental deletions.
- **Unmapped Package Discovery**: Enhanced the "Other Packages" section to identify package names used in transaction remarks that aren't in the master list. Tapping these now prefills the add-package form.
- **Pull-to-Refresh**: Added pull-refresh support to the Inventory screen to sync with the latest spreadsheet data.
- **Enhanced UI/UX**:
    - Standardized price formatting (e.g., `Rp10.000`) and duration labels (e.g., "6 Hours", "3 Days").
    - Improved layout with card-based rows and clearer section headers.
    - Added snackbar feedback for all CRUD operations.

### Implementation
- **Domain/Use Cases**:
    - `SubmitPackageUseCase`, `UpdatePackageUseCase`, `DeletePackageUseCase`: Handle logic for mutating spreadsheet data with retry logic and validation.
    - `PackageMutationValidation`: Centralized logic for duplicate name detection and required field validation.
- **Repository**:
    - `GoogleSheetRepositoryImpl`: Implemented `addPackage` (append), `updatePackage` (targeted row update), and `deletePackage` (batch update row deletion).
    - Updated `readPackageData` to track `sheetRowIndex` for downstream mutations.
- **ViewModel**:
    - `InventoryViewModel`: Manages UI state for loading, saving, and deleting packages, and observes spreadsheet configuration.

### Testing
- **New Test Suites**:
    - `PackageCrudUseCasesTest`: Verifies business logic for package mutations, including duplicate name rejection.
    - `PackageDataExtTest`: Validates mapping between domain models and spreadsheet row formats.
- **Updated Tests**:
    - `InventoryViewModelTest`: Added coverage for CRUD state transitions and refresh logic.
    - `PackageItemTest`: Updated to verify new price formatting and row index mapping.
    - `GetOtherPackageUseCaseTest`: Added cases for case-insensitive normalization.

### Chore
- **CI/CD**: Simplified keystore decoding in GitHub Actions and removed redundant Gradle wrapper "warming" steps.
- **Documentation**: Updated `docs/ui/profile/README.md` and `docs/ui/order/README.md` to reflect the new Inventory capabilities and architectural decisions.