### PR TITLE
chore: Implement macrobenchmark and optimize post-submit Home orchest…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ fastlane/readme.md
 /.jacoco/                   # Jacoco cache dir (if exists)
 /jacoco.exec                # Jacoco execution data
 /coverage/                  # Coverage reports if output here
+*.perfetto-trace            # Android Macrobenchmark/Perfetto trace captures
 
 # --- CI/CD or temporary deployment files ---
 *.pem                       # Private keys

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -85,6 +85,12 @@ android {
             buildConfigField("String", "ADMOB_APP_ID", escapeBuildConfigValue(admobAppIdDebug))
             buildConfigField("String", "ADMOB_BANNER_AD_UNIT_ID", escapeBuildConfigValue(admobBannerAdUnitIdDebug))
         }
+        benchmark {
+            initWith release
+            matchingFallbacks = ['release']
+            debuggable false
+            signingConfig signingConfigs.release
+        }
     }
 
     buildFeatures {
@@ -261,6 +267,7 @@ dependencies {
     implementation "androidx.activity:activity-compose:1.10.1"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
+    debugImplementation "com.squareup.leakcanary:leakcanary-android:2.14"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
 
     // Firebase

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -16,6 +16,18 @@
 # debugging stack traces.
 -keepattributes SourceFile,LineNumberTable
 
+# Gson/R8 needs signature and annotation metadata for reflective adapters and
+# @SerializedName-backed DTO fields in minified release builds.
+-keepattributes Signature,*Annotation*,InnerClasses,EnclosingMethod
+-keep class com.google.gson.reflect.TypeToken { *; }
+-keep class * extends com.google.gson.reflect.TypeToken
+-keep class * implements com.google.gson.TypeAdapterFactory
+-keep class * implements com.google.gson.JsonSerializer
+-keep class * implements com.google.gson.JsonDeserializer
+-keepclassmembers,allowobfuscation class * {
+    @com.google.gson.annotations.SerializedName <fields>;
+}
+
 # Jetpack Compose
 -keep class androidx.compose.** { *; }
 -dontwarn androidx.compose.**
@@ -71,3 +83,9 @@
 
 -keep class com.google.api.** { *; }
 -dontwarn com.google.api.**
+
+# Drive capability response is parsed by Gson during spreadsheet validation.
+# Keep the DTO constructible after R8 so release builds do not surface
+# `Abstract classes can't be instantiated` errors on the spreadsheet setup flow.
+-keep class com.raylabs.laundryhub.core.data.service.GoogleSheetService$DriveFileMetadataResponse { *; }
+-keep class com.raylabs.laundryhub.core.data.service.GoogleSheetService$DriveFileCapabilities { *; }

--- a/app/src/benchmark/AndroidManifest.xml
+++ b/app/src/benchmark/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application>
+        <profileable
+            android:shell="true"
+            tools:targetApi="29" />
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/raylabs/laundryhub/core/data/repository/GSheetRepositoryErrorHandling.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/core/data/repository/GSheetRepositoryErrorHandling.kt
@@ -9,6 +9,8 @@ object GSheetRepositoryErrorHandling {
 
     const val EDIT_ACCESS_REQUIRED_MESSAGE =
         "This Google account can view the spreadsheet but cannot edit it. Ask the owner to grant Editor access before continuing."
+    const val AUTHORIZATION_RECONNECT_REQUIRED_MESSAGE =
+        "Google Sheets access expired or became invalid. Grant Google Sheets access again and try once more."
     const val AUTHORIZATION_CONFIGURATION_MESSAGE =
         "Google Sheets authorization couldn't be completed on this device. Reconnect Google Sheets access and try again."
     const val DRIVE_API_NOT_ENABLED_MESSAGE =
@@ -20,6 +22,13 @@ object GSheetRepositoryErrorHandling {
         val statusMessage = e.statusMessage
         val details = e.details?.message ?: "Unknown Error"
         return when {
+            isInvalidCredentialFailure(
+                statusCode = statusCode,
+                statusMessage = statusMessage,
+                details = details
+            ) ->
+                Resource.Error(AUTHORIZATION_RECONNECT_REQUIRED_MESSAGE)
+
             details.contains("Google Drive API has not been used", ignoreCase = true) ||
                 details.contains("accessNotConfigured", ignoreCase = true) ||
                 details.contains("drive.googleapis.com", ignoreCase = true) &&
@@ -37,8 +46,15 @@ object GSheetRepositoryErrorHandling {
         if (isDriveApiDisabledMessage(e.message)) {
             return Resource.Error(DRIVE_API_NOT_ENABLED_MESSAGE)
         }
+        if (isInvalidCredentialFailure(details = e.message)) {
+            return Resource.Error(AUTHORIZATION_RECONNECT_REQUIRED_MESSAGE)
+        }
         if (
-            e.message?.contains("access token is unavailable", ignoreCase = true) == true ||
+            e.message?.contains("access token is unavailable", ignoreCase = true) == true
+        ) {
+            return Resource.Error(AUTHORIZATION_RECONNECT_REQUIRED_MESSAGE)
+        }
+        if (
             e.message?.contains("DEVELOPER_ERROR", ignoreCase = true) == true ||
             e.message?.contains("Unknown calling package name", ignoreCase = true) == true
         ) {
@@ -72,6 +88,15 @@ object GSheetRepositoryErrorHandling {
 
         if (exception is GoogleJsonResponseException) {
             val details = exception.details?.message.orEmpty()
+            if (
+                isInvalidCredentialFailure(
+                    statusCode = exception.statusCode,
+                    statusMessage = exception.statusMessage,
+                    details = details
+                )
+            ) {
+                return Resource.Error(AUTHORIZATION_RECONNECT_REQUIRED_MESSAGE)
+            }
             return if (
                 exception.statusCode == 403 &&
                 !details.contains("Google Drive API has not been used", ignoreCase = true) &&
@@ -88,11 +113,21 @@ object GSheetRepositoryErrorHandling {
         }
 
         if (
-            exception.message?.contains("access token is unavailable", ignoreCase = true) == true ||
+            exception.message?.contains("access token is unavailable", ignoreCase = true) == true
+        ) {
+            return Resource.Error(AUTHORIZATION_RECONNECT_REQUIRED_MESSAGE)
+        }
+
+        if (
+            isInvalidCredentialFailure(details = exception.message) ||
             exception.message?.contains("DEVELOPER_ERROR", ignoreCase = true) == true ||
             exception.message?.contains("Unknown calling package name", ignoreCase = true) == true
         ) {
-            return Resource.Error(AUTHORIZATION_CONFIGURATION_MESSAGE)
+            return if (isInvalidCredentialFailure(details = exception.message)) {
+                Resource.Error(AUTHORIZATION_RECONNECT_REQUIRED_MESSAGE)
+            } else {
+                Resource.Error(AUTHORIZATION_CONFIGURATION_MESSAGE)
+            }
         }
 
         return Resource.Error(exception.message ?: fallbackMessage)
@@ -103,5 +138,19 @@ object GSheetRepositoryErrorHandling {
         return raw.contains("Google Drive API has not been used", ignoreCase = true) ||
             raw.contains("drive.googleapis.com", ignoreCase = true) && raw.contains("enable", ignoreCase = true) ||
             raw.contains("accessNotConfigured", ignoreCase = true)
+    }
+
+    private fun isInvalidCredentialFailure(
+        statusCode: Int? = null,
+        statusMessage: String? = null,
+        details: String?
+    ): Boolean {
+        val rawDetails = details.orEmpty()
+        val rawStatus = statusMessage.orEmpty()
+        return statusCode == 401 ||
+            rawStatus.contains("Unauthorized", ignoreCase = true) ||
+            rawDetails.contains("invalid authentication credentials", ignoreCase = true) ||
+            rawDetails.contains("Expected OAuth 2 access token", ignoreCase = true) ||
+            rawDetails.contains("login cookie or other valid authentication credential", ignoreCase = true)
     }
 }

--- a/app/src/main/java/com/raylabs/laundryhub/core/data/service/GoogleSheetService.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/core/data/service/GoogleSheetService.kt
@@ -2,12 +2,14 @@ package com.raylabs.laundryhub.core.data.service
 
 import android.net.Uri
 import android.util.Log
+import androidx.annotation.Keep
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.http.GenericUrl
 import com.google.api.client.http.HttpRequestInitializer
 import com.google.api.client.json.gson.GsonFactory
 import com.google.api.services.sheets.v4.Sheets
 import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
@@ -90,12 +92,17 @@ class GoogleSheetService @Inject constructor(
             request.headers.authorization = "Bearer $accessToken"
         }
 
+    @Keep
     private data class DriveFileMetadataResponse(
+        @SerializedName("capabilities")
         val capabilities: DriveFileCapabilities? = null
     )
 
+    @Keep
     private data class DriveFileCapabilities(
+        @SerializedName("canEdit")
         val canEdit: Boolean? = null,
+        @SerializedName("canModifyContent")
         val canModifyContent: Boolean? = null
     )
 }

--- a/app/src/main/java/com/raylabs/laundryhub/core/data/service/GoogleSheetsAuthorizationManagerImpl.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/core/data/service/GoogleSheetsAuthorizationManagerImpl.kt
@@ -17,26 +17,13 @@ class GoogleSheetsAuthorizationManagerImpl @Inject constructor(
     private val googleSheetsAccountProvider: GoogleSheetsAccountProvider
 ) : GoogleSheetsAuthorizationManager {
 
-    @Volatile
-    private var cachedEmail: String? = null
-
-    @Volatile
-    private var cachedAccessToken: String? = null
-
     override fun getSignedInEmail(): String? = googleSheetsAccountProvider.getSignedInEmail()
 
     override suspend fun hasSheetsAccess(): Boolean {
         val signedInEmail = getSignedInEmail()
         if (signedInEmail.isNullOrBlank()) {
-            clearAuthorizationCache()
             Log.d(TAG, "hasSheetsAccess skipped because there is no signed-in Google email")
             return false
-        }
-
-        invalidateCacheIfAccountChanged(signedInEmail)
-        cachedAccessToken?.let {
-            Log.d(TAG, "hasSheetsAccess satisfied from cached token for email=$signedInEmail")
-            return true
         }
 
         val result = authorizeCurrentAccount() ?: return false
@@ -53,15 +40,8 @@ class GoogleSheetsAuthorizationManagerImpl @Inject constructor(
     override suspend fun getAccessToken(): String? {
         val signedInEmail = getSignedInEmail()
         if (signedInEmail.isNullOrBlank()) {
-            clearAuthorizationCache()
             Log.w(TAG, "getAccessToken called without signed-in email")
             return null
-        }
-
-        invalidateCacheIfAccountChanged(signedInEmail)
-        cachedAccessToken?.let {
-            Log.d(TAG, "getAccessToken returned cached token for email=$signedInEmail")
-            return it
         }
 
         val result = authorizeCurrentAccount() ?: return null
@@ -76,14 +56,7 @@ class GoogleSheetsAuthorizationManagerImpl @Inject constructor(
     override suspend fun getAuthorizationIntentSender(): IntentSender? {
         val signedInEmail = getSignedInEmail()
         if (signedInEmail.isNullOrBlank()) {
-            clearAuthorizationCache()
             Log.w(TAG, "getAuthorizationIntentSender called without signed-in email")
-            return null
-        }
-
-        invalidateCacheIfAccountChanged(signedInEmail)
-        if (cachedAccessToken != null) {
-            Log.d(TAG, "getAuthorizationIntentSender skipped because token is already cached for email=$signedInEmail")
             return null
         }
 
@@ -108,15 +81,8 @@ class GoogleSheetsAuthorizationManagerImpl @Inject constructor(
         return runCatching {
             authorizationClient.getAuthorizationResultFromIntent(data)
                 .let { result ->
-                    val granted = !result.accessToken.isNullOrBlank() &&
+                    !result.accessToken.isNullOrBlank() &&
                         result.grantedScopes.hasRequiredSpreadsheetScopes()
-                    if (granted) {
-                        cacheAuthorization(
-                            signedInEmail = getSignedInEmail(),
-                            accessToken = result.accessToken
-                        )
-                    }
-                    granted
                 }
         }.onSuccess { granted ->
             Log.d(TAG, "handleAuthorizationResult granted=$granted")
@@ -139,36 +105,9 @@ class GoogleSheetsAuthorizationManagerImpl @Inject constructor(
         return runCatching {
             Log.d(TAG, "authorizeCurrentAccount started for email=$signedInEmail")
             authorizationClient.authorize(request).await()
-        }.onSuccess { result ->
-            if (!result.hasResolution() && result.grantedScopes.hasRequiredSpreadsheetScopes()) {
-                cacheAuthorization(
-                    signedInEmail = signedInEmail,
-                    accessToken = result.accessToken
-                )
-            }
         }.onFailure { throwable ->
             logAuthorizationFailure("authorizeCurrentAccount email=$signedInEmail", throwable)
         }.getOrThrow()
-    }
-
-    private fun invalidateCacheIfAccountChanged(signedInEmail: String) {
-        if (cachedEmail != null && cachedEmail != signedInEmail) {
-            Log.d(TAG, "Clearing cached Google Sheets token because signed-in email changed from $cachedEmail to $signedInEmail")
-            clearAuthorizationCache()
-        }
-    }
-
-    private fun cacheAuthorization(signedInEmail: String?, accessToken: String?) {
-        val normalizedEmail = signedInEmail?.takeIf { it.isNotBlank() } ?: return
-        val normalizedToken = accessToken?.takeIf { it.isNotBlank() } ?: return
-        cachedEmail = normalizedEmail
-        cachedAccessToken = normalizedToken
-        Log.d(TAG, "Cached Google Sheets token for email=$normalizedEmail")
-    }
-
-    private fun clearAuthorizationCache() {
-        cachedEmail = null
-        cachedAccessToken = null
     }
 
     private fun List<String>.hasRequiredSpreadsheetScopes(): Boolean =

--- a/app/src/main/java/com/raylabs/laundryhub/ui/LaundryHubStarter.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/LaundryHubStarter.kt
@@ -79,6 +79,7 @@ import com.raylabs.laundryhub.ui.spreadsheet.SpreadsheetSetupScreen
 import com.raylabs.laundryhub.ui.spreadsheet.SpreadsheetSetupViewModel
 import com.raylabs.laundryhub.ui.theme.modalSheetTop
 import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -394,6 +395,7 @@ fun LaundryHubStarter(
     }
 
     BottomSheetScaffold(
+        modifier = modifier,
         scaffoldState = scaffoldState,
         sheetPeekHeight = 0.dp,
         sheetShape = MaterialTheme.shapes.modalSheetTop,
@@ -447,7 +449,7 @@ fun LaundryHubStarter(
                     })
                 }
             },
-            modifier = modifier
+            modifier = Modifier
         ) { innerPadding ->
             NavHost(
                 navController = navController,
@@ -495,12 +497,7 @@ fun LaundryHubStarter(
                             }
                         },
                         onOrderChanged = {
-                            scope.launch {
-                                homeViewModel.fetchOrder()
-                                homeViewModel.fetchTodayIncome()
-                                homeViewModel.fetchSummary()
-                                homeViewModel.fetchGross()
-                            }
+                            scope.launchOrderChangedRefresh(homeViewModel)
                         }
                     )
                 }
@@ -508,10 +505,7 @@ fun LaundryHubStarter(
                     OutcomeScreenView(
                         bannerState = outcomeBannerState,
                         onOutcomeChanged = {
-                            scope.launch {
-                                homeViewModel.fetchSummary()
-                                homeViewModel.fetchGross()
-                            }
+                            scope.launchOutcomeChangedRefresh(homeViewModel)
                         }
                     )
                 }
@@ -600,11 +594,7 @@ fun ShowOrderBottomSheet(
                     orderViewModel.uiState.value.toOrderData(orderId),
                     onComplete = {
                         val submittedState = orderViewModel.uiState.value
-                        homeViewModel.fetchOrder()
-                        homeViewModel.fetchTodayIncome()
-                        homeViewModel.fetchSummary()
-                        homeViewModel.fetchGross()
-                        delay(500)
+                        scope.launchOrderChangedRefresh(homeViewModel)
                         dismissSheet()
 
                         val phone = submittedState.phone
@@ -636,11 +626,7 @@ fun ShowOrderBottomSheet(
                 orderViewModel.updateOrder(
                     uiState.toOrderData(uiState.orderID),
                     onComplete = {
-                        homeViewModel.fetchOrder()
-                        homeViewModel.fetchTodayIncome()
-                        homeViewModel.fetchSummary()
-                        homeViewModel.fetchGross()
-                        delay(500)
+                        scope.launchOrderChangedRefresh(homeViewModel)
                         dismissSheet()
                         snackBarHostState.showSnackbar(
                             context.getString(R.string.order_update_success, uiState.orderID)
@@ -653,6 +639,26 @@ fun ShowOrderBottomSheet(
             }
         }
     )
+}
+
+private fun CoroutineScope.launchOrderChangedRefresh(homeViewModel: HomeViewModel) {
+    launch {
+        runCatching { homeViewModel.refreshAfterOrderChanged() }
+            .onFailure { error ->
+                if (error is CancellationException) throw error
+                Log.w("LaundryHubStarter", "Home refresh after order change failed", error)
+            }
+    }
+}
+
+private fun CoroutineScope.launchOutcomeChangedRefresh(homeViewModel: HomeViewModel) {
+    launch {
+        runCatching { homeViewModel.refreshAfterOutcomeChanged() }
+            .onFailure { error ->
+                if (error is CancellationException) throw error
+                Log.w("LaundryHubStarter", "Home refresh after outcome change failed", error)
+            }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/raylabs/laundryhub/ui/component/SelectionControls.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/component/SelectionControls.kt
@@ -36,6 +36,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -134,6 +136,9 @@ fun <T> HorizontalSelectionCards(
                 Surface(
                     modifier = Modifier
                         .width(208.dp)
+                        .semantics {
+                            contentDescription = "$label option ${optionTitle(option)}"
+                        }
                         .clickable { onOptionSelected(option) },
                     shape = MaterialTheme.shapes.medium,
                     color = cardBackground,

--- a/app/src/main/java/com/raylabs/laundryhub/ui/home/HomeScreenView.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/home/HomeScreenView.kt
@@ -48,6 +48,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -68,6 +70,8 @@ import com.raylabs.laundryhub.ui.home.state.ReminderDiscoveryUiState
 import com.raylabs.laundryhub.ui.home.state.SortOption
 import com.raylabs.laundryhub.ui.home.state.SummaryItem
 import com.raylabs.laundryhub.ui.home.state.TransactionItem
+
+private const val PENDING_ORDER_SEARCH_FIELD_DESCRIPTION = "Pending order search field"
 
 @Composable
 fun HomeScreen(
@@ -232,7 +236,11 @@ fun HomeScreenContent(
                         OutlinedTextField(
                             value = state.searchQuery,
                             onValueChange = onSearchQueryChanged,
-                            modifier = Modifier.weight(1f),
+                            modifier = Modifier
+                                .weight(1f)
+                                .semantics {
+                                    contentDescription = PENDING_ORDER_SEARCH_FIELD_DESCRIPTION
+                                },
                             placeholder = { 
                                 Text(
                                     stringResource(R.string.search_customer_placeholder),

--- a/app/src/main/java/com/raylabs/laundryhub/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/home/HomeViewModel.kt
@@ -29,6 +29,7 @@ import com.raylabs.laundryhub.ui.home.state.toUi
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -356,18 +357,36 @@ class HomeViewModel @Inject constructor(
         } // Reset search on refresh
         viewModelScope.launch {
             try {
-                fetchUser()
-                val jobs = listOf(
-                    async { fetchTodayIncome() },
-                    async { fetchSummary() },
-                    async { fetchGross() },
-                    async { fetchOrder() }, // fetchOrder will call updateDisplayedUnpaidOrders
-                    async { fetchReminderDiscoveryData() }
-                )
-                jobs.awaitAll()
+                refreshHomeSections()
             } finally {
                 _uiState.update { it.copy(isRefreshing = false) }
             }
+        }
+    }
+
+    suspend fun refreshAfterOrderChanged() {
+        refreshHomeSections()
+    }
+
+    suspend fun refreshAfterOutcomeChanged() {
+        coroutineScope {
+            listOf(
+                async { fetchSummary() },
+                async { fetchGross() }
+            ).awaitAll()
+        }
+    }
+
+    private suspend fun refreshHomeSections() {
+        fetchUser()
+        coroutineScope {
+            listOf(
+                async { fetchTodayIncome() },
+                async { fetchSummary() },
+                async { fetchGross() },
+                async { fetchOrder() }, // fetchOrder will call updateDisplayedUnpaidOrders
+                async { fetchReminderDiscoveryData() }
+            ).awaitAll()
         }
     }
 

--- a/app/src/main/java/com/raylabs/laundryhub/ui/order/OrderBottomSheetScreen.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/order/OrderBottomSheetScreen.kt
@@ -14,8 +14,10 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
@@ -28,6 +30,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
@@ -44,6 +48,12 @@ import com.raylabs.laundryhub.ui.order.state.isSubmitEnabled
 import com.raylabs.laundryhub.ui.order.state.isUpdateEnabled
 import com.raylabs.laundryhub.ui.profile.inventory.state.PackageItem
 import com.raylabs.laundryhub.ui.theme.modalSheetTop
+
+private const val ORDER_SHEET_DESCRIPTION = "Order sheet"
+private const val ORDER_NAME_FIELD_DESCRIPTION = "Order name field"
+private const val ORDER_PRICE_FIELD_DESCRIPTION = "Order price field"
+private const val ORDER_SUBMIT_BUTTON_DESCRIPTION = "Submit order"
+private const val ORDER_UPDATE_BUTTON_DESCRIPTION = "Update order"
 
 @Composable
 fun OrderBottomSheet(
@@ -72,12 +82,16 @@ fun OrderBottomSheet(
             .fillMaxWidth()
             .wrapContentHeight(unbounded = true)
             .heightIn(max = 900.dp)
+            .semantics {
+                contentDescription = ORDER_SHEET_DESCRIPTION
+            }
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .wrapContentHeight(unbounded = true)
                 .heightIn(max = 900.dp)
+                .verticalScroll(rememberScrollState())
                 .background(
                     MaterialTheme.colors.surface,
                     shape = MaterialTheme.shapes.modalSheetTop
@@ -108,7 +122,11 @@ fun OrderBottomSheet(
                     imeAction = ImeAction.Next
                 ),
                 label = { Text("Name") },
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics {
+                        contentDescription = ORDER_NAME_FIELD_DESCRIPTION
+                    }
             )
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -198,14 +216,18 @@ fun OrderBottomSheet(
                     keyboardType = KeyboardType.Number
                 ),
                 label = { Text("Price") },
-                modifier = Modifier.fillMaxWidth(),
                 leadingIcon = {
                     Text("Rp", modifier = Modifier.padding(start = 4.dp))
                 },
                 trailingIcon = {
                     Text(",-", modifier = Modifier.padding(end = 4.dp))
                 },
-                singleLine = true
+                singleLine = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics {
+                        contentDescription = ORDER_PRICE_FIELD_DESCRIPTION
+                    }
             )
 
             Text(
@@ -248,7 +270,15 @@ fun OrderBottomSheet(
                     isSubmitting = state.isSubmitting,
                     onSubmit = onSubmit,
                     onUpdate = onUpdate,
-                    modifier = Modifier.align(Alignment.Bottom),
+                    modifier = Modifier
+                        .align(Alignment.Bottom)
+                        .semantics {
+                            contentDescription = if (state.isEditMode) {
+                                ORDER_UPDATE_BUTTON_DESCRIPTION
+                            } else {
+                                ORDER_SUBMIT_BUTTON_DESCRIPTION
+                            }
+                        },
                     fillMaxWidth = false
                 )
             }

--- a/app/src/main/java/com/raylabs/laundryhub/ui/spreadsheet/SpreadsheetSetupViewModel.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/spreadsheet/SpreadsheetSetupViewModel.kt
@@ -182,11 +182,14 @@ class SpreadsheetSetupViewModel @Inject constructor(
         if (message == GSheetRepositoryErrorHandling.AUTHORIZATION_CONFIGURATION_MESSAGE) {
             return false
         }
+        if (message == GSheetRepositoryErrorHandling.AUTHORIZATION_RECONNECT_REQUIRED_MESSAGE) {
+            return true
+        }
         if (message == GSheetRepositoryErrorHandling.DRIVE_API_NOT_ENABLED_MESSAGE) {
             return false
         }
         if (message.contains("access token is unavailable", ignoreCase = true)) {
-            return false
+            return true
         }
         if (message.contains("developer_error", ignoreCase = true)) {
             return false
@@ -214,6 +217,9 @@ class SpreadsheetSetupViewModel @Inject constructor(
             rawMessage == GSheetRepositoryErrorHandling.AUTHORIZATION_CONFIGURATION_MESSAGE ->
                 GOOGLE_SHEETS_RECONNECT_MESSAGE
 
+            rawMessage == GSheetRepositoryErrorHandling.AUTHORIZATION_RECONNECT_REQUIRED_MESSAGE ->
+                GOOGLE_SHEETS_ACCESS_EXPIRED_MESSAGE
+
             rawMessage == GSheetRepositoryErrorHandling.DRIVE_API_NOT_ENABLED_MESSAGE ->
                 DRIVE_API_NOT_ENABLED_FRIENDLY_MESSAGE
 
@@ -239,6 +245,8 @@ class SpreadsheetSetupViewModel @Inject constructor(
             "Connect Google Sheets first to continue."
         const val GOOGLE_SHEETS_RECONNECT_MESSAGE =
             "Google Sheets couldn't reconnect cleanly on this device. Try granting access again."
+        const val GOOGLE_SHEETS_ACCESS_EXPIRED_MESSAGE =
+            "Google Sheets access expired. Grant access again to continue."
         const val EDITOR_ACCESS_REQUIRED_MESSAGE =
             "This account can open the spreadsheet, but it still needs Editor access."
         const val DRIVE_API_NOT_ENABLED_FRIENDLY_MESSAGE =

--- a/app/src/test/java/com/raylabs/laundryhub/core/data/repository/GSheetRepositoryErrorHandlingTest.kt
+++ b/app/src/test/java/com/raylabs/laundryhub/core/data/repository/GSheetRepositoryErrorHandlingTest.kt
@@ -28,6 +28,22 @@ class GSheetRepositoryErrorHandlingTest {
     }
 
     @Test
+    fun `handleGoogleJsonResponseException maps invalid credentials to reconnect message`() {
+        val result = GSheetRepositoryErrorHandling.handleGoogleJsonResponseException(
+            googleJsonException(
+                statusCode = 401,
+                statusMessage = "Unauthorized",
+                detailsMessage = "Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential."
+            )
+        )
+
+        assertEquals(
+            GSheetRepositoryErrorHandling.AUTHORIZATION_RECONNECT_REQUIRED_MESSAGE,
+            result.message
+        )
+    }
+
+    @Test
     fun `handleGoogleJsonResponseException returns generic error for non drive failures`() {
         val result = GSheetRepositoryErrorHandling.handleGoogleJsonResponseException(
             googleJsonException(
@@ -60,6 +76,18 @@ class GSheetRepositoryErrorHandlingTest {
 
         assertEquals(
             GSheetRepositoryErrorHandling.AUTHORIZATION_CONFIGURATION_MESSAGE,
+            result.message
+        )
+    }
+
+    @Test
+    fun `handleReadSheetResponseException maps invalid credential message to reconnect message`() {
+        val result = GSheetRepositoryErrorHandling.handleReadSheetResponseException(
+            Exception("Error 401: Unauthorized. Request had invalid authentication credentials.")
+        )
+
+        assertEquals(
+            GSheetRepositoryErrorHandling.AUTHORIZATION_RECONNECT_REQUIRED_MESSAGE,
             result.message
         )
     }
@@ -134,11 +162,23 @@ class GSheetRepositoryErrorHandlingTest {
     @Test
     fun `handleFailedUpdate maps auth configuration issue`() {
         val result = GSheetRepositoryErrorHandling.handleFailedUpdate(
-            Exception("access token is unavailable for owner@laundryhub.com")
+            Exception("DEVELOPER_ERROR: Unknown calling package name com.google.android.gms")
         )
 
         assertEquals(
             GSheetRepositoryErrorHandling.AUTHORIZATION_CONFIGURATION_MESSAGE,
+            result.message
+        )
+    }
+
+    @Test
+    fun `handleFailedUpdate maps missing access token to reconnect message`() {
+        val result = GSheetRepositoryErrorHandling.handleFailedUpdate(
+            Exception("access token is unavailable for owner@laundryhub.com")
+        )
+
+        assertEquals(
+            GSheetRepositoryErrorHandling.AUTHORIZATION_RECONNECT_REQUIRED_MESSAGE,
             result.message
         )
     }

--- a/app/src/test/java/com/raylabs/laundryhub/core/data/repository/GoogleSheetRepositoryImplPerformanceBaselineTest.kt
+++ b/app/src/test/java/com/raylabs/laundryhub/core/data/repository/GoogleSheetRepositoryImplPerformanceBaselineTest.kt
@@ -1,0 +1,119 @@
+package com.raylabs.laundryhub.core.data.repository
+
+import com.google.api.services.sheets.v4.model.ValueRange
+import com.raylabs.laundryhub.core.data.service.GoogleSheetService
+import com.raylabs.laundryhub.core.domain.model.sheets.CASH
+import com.raylabs.laundryhub.core.domain.model.sheets.FILTER
+import com.raylabs.laundryhub.core.domain.model.sheets.PAID
+import com.raylabs.laundryhub.core.domain.model.sheets.UNPAID_ID
+import com.raylabs.laundryhub.core.domain.repository.SpreadsheetIdProvider
+import com.raylabs.laundryhub.ui.common.util.Resource
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.system.measureTimeMillis
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GoogleSheetRepositoryImplPerformanceBaselineTest {
+
+    private lateinit var googleSheetService: GoogleSheetService
+    private lateinit var spreadsheetIdProvider: SpreadsheetIdProvider
+    private lateinit var repo: GoogleSheetRepositoryImpl
+
+    @Before
+    fun setup() {
+        googleSheetService = mock()
+        spreadsheetIdProvider = mock()
+        runBlocking {
+            whenever(spreadsheetIdProvider.getSpreadsheetId()).thenReturn(TEST_SPREADSHEET_ID)
+        }
+        repo = GoogleSheetRepositoryImpl(googleSheetService, spreadsheetIdProvider)
+    }
+
+    @Test
+    fun `readIncomeTransaction unpaid baseline logs elapsed time for large dataset`() = runTest {
+        val rowCount = 5_000
+        val unpaidEvery = 3
+        val expectedUnpaidCount = rowCount / unpaidEvery
+
+        val sheets = mock<com.google.api.services.sheets.v4.Sheets>()
+        val spreadsheets = mock<com.google.api.services.sheets.v4.Sheets.Spreadsheets>()
+        val values = mock<com.google.api.services.sheets.v4.Sheets.Spreadsheets.Values>()
+        val get = mock<com.google.api.services.sheets.v4.Sheets.Spreadsheets.Values.Get>()
+        val valueRange = mock<ValueRange>()
+
+        whenever(googleSheetService.getSheetsService()).thenReturn(sheets)
+        whenever(sheets.spreadsheets()).thenReturn(spreadsheets)
+        whenever(spreadsheets.values()).thenReturn(values)
+        whenever(values.get(any(), any())).thenReturn(get)
+        whenever(get.execute()).thenReturn(valueRange)
+        whenever(valueRange.getValues()).thenReturn(buildIncomeSheetRows(rowCount, unpaidEvery))
+
+        lateinit var result: Resource<List<com.raylabs.laundryhub.core.domain.model.sheets.TransactionData>>
+        val elapsedMs = measureTimeMillis {
+            result = repo.readIncomeTransaction(FILTER.SHOW_UNPAID_DATA, null)
+        }
+
+        assertTrue(result is Resource.Success)
+        val data = (result as Resource.Success).data
+        assertEquals(expectedUnpaidCount, data.size)
+        assertTrue(data.first().orderID.isNotBlank())
+        assertTrue(elapsedMs >= 0)
+
+        println(
+            "PERF_BASELINE repository=GoogleSheetRepositoryImpl " +
+                "method=readIncomeTransaction filter=SHOW_UNPAID_DATA rows=$rowCount " +
+                "expected_unpaid=$expectedUnpaidCount elapsed_ms=$elapsedMs"
+        )
+    }
+
+    private fun buildIncomeSheetRows(rowCount: Int, unpaidEvery: Int): List<List<Any>> {
+        val header = listOf(
+            "orderID",
+            "Date",
+            "Name",
+            "Weight",
+            "Price/kg",
+            "Total Price",
+            "(lunas/belum)",
+            "Package",
+            "remark",
+            "payment",
+            "phoneNumber",
+            "due date"
+        )
+
+        val rows = (1..rowCount).map { index ->
+            val day = ((index - 1) % 28) + 1
+            val paymentStatus = if (index % unpaidEvery == 0) UNPAID_ID else PAID
+            val paymentMethod = if (paymentStatus == PAID) CASH else ""
+            listOf(
+                "ORD-$index",
+                "%02d/03/2026".format(day),
+                "Customer $index",
+                "1",
+                "7000",
+                "7000",
+                paymentStatus,
+                "Regular",
+                "",
+                paymentMethod,
+                "08$index",
+                "%02d/03/2026".format(day + 1)
+            )
+        }
+
+        return listOf(header) + rows
+    }
+
+    companion object {
+        private const val TEST_SPREADSHEET_ID = "spreadsheet-id"
+    }
+}

--- a/app/src/test/java/com/raylabs/laundryhub/core/data/repository/SpreadsheetValidationRepositoryImplTest.kt
+++ b/app/src/test/java/com/raylabs/laundryhub/core/data/repository/SpreadsheetValidationRepositoryImplTest.kt
@@ -155,7 +155,7 @@ class SpreadsheetValidationRepositoryImplTest {
         val result = repository.validateSpreadsheet(INPUT_URL)
 
         assertEquals(
-            Resource.Error(GSheetRepositoryErrorHandling.AUTHORIZATION_CONFIGURATION_MESSAGE),
+            Resource.Error(GSheetRepositoryErrorHandling.AUTHORIZATION_RECONNECT_REQUIRED_MESSAGE),
             result
         )
     }

--- a/app/src/test/java/com/raylabs/laundryhub/core/data/service/GoogleSheetsAuthorizationManagerImplTest.kt
+++ b/app/src/test/java/com/raylabs/laundryhub/core/data/service/GoogleSheetsAuthorizationManagerImplTest.kt
@@ -181,45 +181,69 @@ class GoogleSheetsAuthorizationManagerImplTest {
     }
 
     @Test
-    fun `getAccessToken reuses cached token after first authorization`() = runTest {
+    fun `getAccessToken requests a fresh authorization result each time`() = runTest {
         whenever(accountProvider.getSignedInEmail()).thenReturn("owner@laundryhub.com")
-        val result: AuthorizationResult = mock()
-        whenever(result.hasResolution()).thenReturn(false)
-        whenever(result.accessToken).thenReturn("token")
-        whenever(result.grantedScopes).thenReturn(
+        val firstResult: AuthorizationResult = mock()
+        whenever(firstResult.hasResolution()).thenReturn(false)
+        whenever(firstResult.accessToken).thenReturn("token-1")
+        whenever(firstResult.grantedScopes).thenReturn(
             listOf(
                 SheetsScopes.SPREADSHEETS,
                 GoogleSheetService.DRIVE_METADATA_READONLY_SCOPE
             )
         )
-        whenever(authorizationClient.authorize(any())).thenReturn(Tasks.forResult(result))
+        val secondResult: AuthorizationResult = mock()
+        whenever(secondResult.hasResolution()).thenReturn(false)
+        whenever(secondResult.accessToken).thenReturn("token-2")
+        whenever(secondResult.grantedScopes).thenReturn(
+            listOf(
+                SheetsScopes.SPREADSHEETS,
+                GoogleSheetService.DRIVE_METADATA_READONLY_SCOPE
+            )
+        )
+        whenever(authorizationClient.authorize(any())).thenReturn(
+            Tasks.forResult(firstResult),
+            Tasks.forResult(secondResult)
+        )
 
         val manager = GoogleSheetsAuthorizationManagerImpl(authorizationClient, accountProvider)
 
-        assertEquals("token", manager.getAccessToken())
-        assertEquals("token", manager.getAccessToken())
-        verify(authorizationClient, times(1)).authorize(any())
+        assertEquals("token-1", manager.getAccessToken())
+        assertEquals("token-2", manager.getAccessToken())
+        verify(authorizationClient, times(2)).authorize(any())
     }
 
     @Test
-    fun `hasSheetsAccess reuses cached token after first authorization`() = runTest {
+    fun `hasSheetsAccess rechecks authorization instead of trusting an old cached token`() = runTest {
         whenever(accountProvider.getSignedInEmail()).thenReturn("owner@laundryhub.com")
-        val result: AuthorizationResult = mock()
-        whenever(result.hasResolution()).thenReturn(false)
-        whenever(result.accessToken).thenReturn("token")
-        whenever(result.grantedScopes).thenReturn(
+        val firstResult: AuthorizationResult = mock()
+        whenever(firstResult.hasResolution()).thenReturn(false)
+        whenever(firstResult.accessToken).thenReturn("token-1")
+        whenever(firstResult.grantedScopes).thenReturn(
             listOf(
                 SheetsScopes.SPREADSHEETS,
                 GoogleSheetService.DRIVE_METADATA_READONLY_SCOPE
             )
         )
-        whenever(authorizationClient.authorize(any())).thenReturn(Tasks.forResult(result))
+        val secondResult: AuthorizationResult = mock()
+        whenever(secondResult.hasResolution()).thenReturn(false)
+        whenever(secondResult.accessToken).thenReturn("token-2")
+        whenever(secondResult.grantedScopes).thenReturn(
+            listOf(
+                SheetsScopes.SPREADSHEETS,
+                GoogleSheetService.DRIVE_METADATA_READONLY_SCOPE
+            )
+        )
+        whenever(authorizationClient.authorize(any())).thenReturn(
+            Tasks.forResult(firstResult),
+            Tasks.forResult(secondResult)
+        )
 
         val manager = GoogleSheetsAuthorizationManagerImpl(authorizationClient, accountProvider)
 
         assertTrue(manager.hasSheetsAccess())
         assertTrue(manager.hasSheetsAccess())
-        verify(authorizationClient, times(1)).authorize(any())
+        verify(authorizationClient, times(2)).authorize(any())
     }
 
     @Test
@@ -264,61 +288,38 @@ class GoogleSheetsAuthorizationManagerImplTest {
     }
 
     @Test
-    fun `getAuthorizationIntentSender returns null when token is already cached`() = runTest {
+    fun `getAuthorizationIntentSender rechecks authorization even after access was previously granted`() = runTest {
         whenever(accountProvider.getSignedInEmail()).thenReturn("owner@laundryhub.com")
-        val result: AuthorizationResult = mock()
-        whenever(result.hasResolution()).thenReturn(false)
-        whenever(result.accessToken).thenReturn("token")
-        whenever(result.grantedScopes).thenReturn(
+        val grantedResult: AuthorizationResult = mock()
+        whenever(grantedResult.hasResolution()).thenReturn(false)
+        whenever(grantedResult.accessToken).thenReturn("token")
+        whenever(grantedResult.grantedScopes).thenReturn(
             listOf(
                 SheetsScopes.SPREADSHEETS,
                 GoogleSheetService.DRIVE_METADATA_READONLY_SCOPE
             )
         )
-        whenever(authorizationClient.authorize(any())).thenReturn(Tasks.forResult(result))
+        val pendingIntent: PendingIntent = mock()
+        val intentSender: IntentSender = mock()
+        val resolutionResult: AuthorizationResult = mock()
+        whenever(resolutionResult.hasResolution()).thenReturn(true)
+        whenever(resolutionResult.pendingIntent).thenReturn(pendingIntent)
+        whenever(pendingIntent.intentSender).thenReturn(intentSender)
+        whenever(resolutionResult.grantedScopes).thenReturn(
+            listOf(
+                SheetsScopes.SPREADSHEETS,
+                GoogleSheetService.DRIVE_METADATA_READONLY_SCOPE
+            )
+        )
+        whenever(authorizationClient.authorize(any())).thenReturn(
+            Tasks.forResult(grantedResult),
+            Tasks.forResult(resolutionResult)
+        )
 
         val manager = GoogleSheetsAuthorizationManagerImpl(authorizationClient, accountProvider)
 
         assertTrue(manager.hasSheetsAccess())
-        assertEquals(null, manager.getAuthorizationIntentSender())
-        verify(authorizationClient, times(1)).authorize(any())
-    }
-
-    @Test
-    fun `cached token is invalidated when signed in email changes`() = runTest {
-        var email = "owner1@laundryhub.com"
-        whenever(accountProvider.getSignedInEmail()).thenAnswer { email }
-
-        val firstResult: AuthorizationResult = mock()
-        whenever(firstResult.hasResolution()).thenReturn(false)
-        whenever(firstResult.accessToken).thenReturn("token-1")
-        whenever(firstResult.grantedScopes).thenReturn(
-            listOf(
-                SheetsScopes.SPREADSHEETS,
-                GoogleSheetService.DRIVE_METADATA_READONLY_SCOPE
-            )
-        )
-
-        val secondResult: AuthorizationResult = mock()
-        whenever(secondResult.hasResolution()).thenReturn(false)
-        whenever(secondResult.accessToken).thenReturn("token-2")
-        whenever(secondResult.grantedScopes).thenReturn(
-            listOf(
-                SheetsScopes.SPREADSHEETS,
-                GoogleSheetService.DRIVE_METADATA_READONLY_SCOPE
-            )
-        )
-
-        whenever(authorizationClient.authorize(any())).thenReturn(
-            Tasks.forResult(firstResult),
-            Tasks.forResult(secondResult)
-        )
-
-        val manager = GoogleSheetsAuthorizationManagerImpl(authorizationClient, accountProvider)
-
-        assertEquals("token-1", manager.getAccessToken())
-        email = "owner2@laundryhub.com"
-        assertEquals("token-2", manager.getAccessToken())
+        assertEquals(intentSender, manager.getAuthorizationIntentSender())
         verify(authorizationClient, times(2)).authorize(any())
     }
 }

--- a/app/src/test/java/com/raylabs/laundryhub/ui/home/HomeViewModelPerformanceBaselineTest.kt
+++ b/app/src/test/java/com/raylabs/laundryhub/ui/home/HomeViewModelPerformanceBaselineTest.kt
@@ -1,0 +1,217 @@
+package com.raylabs.laundryhub.ui.home
+
+import com.raylabs.laundryhub.core.domain.model.auth.User
+import com.raylabs.laundryhub.core.domain.model.reminder.ReminderSettings
+import com.raylabs.laundryhub.core.domain.model.sheets.FILTER
+import com.raylabs.laundryhub.core.domain.model.sheets.GrossData
+import com.raylabs.laundryhub.core.domain.model.sheets.OrderData
+import com.raylabs.laundryhub.core.domain.model.sheets.OutcomeData
+import com.raylabs.laundryhub.core.domain.model.sheets.PackageData
+import com.raylabs.laundryhub.core.domain.model.sheets.RangeDate
+import com.raylabs.laundryhub.core.domain.model.sheets.SpreadsheetData
+import com.raylabs.laundryhub.core.domain.model.sheets.TransactionData
+import com.raylabs.laundryhub.core.domain.repository.GoogleSheetRepository
+import com.raylabs.laundryhub.core.domain.usecase.reminder.EvaluateReminderCandidatesUseCase
+import com.raylabs.laundryhub.core.domain.usecase.reminder.ObserveReminderLocalStatesUseCase
+import com.raylabs.laundryhub.core.domain.usecase.reminder.ObserveReminderSettingsUseCase
+import com.raylabs.laundryhub.core.domain.usecase.sheets.ReadGrossDataUseCase
+import com.raylabs.laundryhub.core.domain.usecase.sheets.ReadSpreadsheetDataUseCase
+import com.raylabs.laundryhub.core.domain.usecase.sheets.income.ReadIncomeTransactionUseCase
+import com.raylabs.laundryhub.core.domain.usecase.user.UserUseCase
+import com.raylabs.laundryhub.ui.common.util.Resource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelPerformanceBaselineTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var slowRepository: SlowGoogleSheetRepository
+    private lateinit var mockUserUseCase: UserUseCase
+    private lateinit var mockObserveReminderSettingsUseCase: ObserveReminderSettingsUseCase
+    private lateinit var mockObserveReminderLocalStatesUseCase: ObserveReminderLocalStatesUseCase
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        slowRepository = SlowGoogleSheetRepository(perCallDelayMs = 1_000L)
+        mockUserUseCase = mock()
+        mockObserveReminderSettingsUseCase = mock()
+        mockObserveReminderLocalStatesUseCase = mock()
+
+        whenever(mockUserUseCase.getCurrentUser()).thenReturn(
+            User(uid = "perf-user", displayName = "Perf User", email = "perf@raylabs.com", urlPhoto = "")
+        )
+        whenever(mockObserveReminderSettingsUseCase.invoke()).thenReturn(flowOf(ReminderSettings()))
+        whenever(mockObserveReminderLocalStatesUseCase.invoke()).thenReturn(flowOf(emptyMap()))
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `refreshAllData baseline keeps fetch orchestration parallel`() = runTest(testDispatcher.scheduler) {
+        val vm = createViewModel()
+
+        advanceUntilIdle() // settle init work first
+
+        val beforeSummaryCalls = slowRepository.summaryCalls
+        val beforeGrossCalls = slowRepository.grossCalls
+        val beforeTodayCalls = slowRepository.todayIncomeCalls
+        val beforeUnpaidCalls = slowRepository.unpaidCalls
+        val beforeAllCalls = slowRepository.allIncomeCalls
+
+        val startedAt = currentTime
+        vm.refreshAllData()
+
+        assertTrue(vm.uiState.value.isRefreshing)
+
+        advanceUntilIdle()
+
+        val elapsedMs = currentTime - startedAt
+        assertEquals(1_000L, elapsedMs)
+        assertEquals(beforeSummaryCalls + 1, slowRepository.summaryCalls)
+        assertEquals(beforeGrossCalls + 1, slowRepository.grossCalls)
+        assertEquals(beforeTodayCalls + 1, slowRepository.todayIncomeCalls)
+        assertEquals(beforeUnpaidCalls + 1, slowRepository.unpaidCalls)
+        assertEquals(beforeAllCalls + 1, slowRepository.allIncomeCalls)
+        assertFalse(vm.uiState.value.isRefreshing)
+
+        println(
+            "PERF_BASELINE owner=HomeViewModel method=refreshAllData " +
+                "virtual_elapsed_ms=$elapsedMs per_call_delay_ms=${slowRepository.perCallDelayMs} " +
+                "sequential_equivalent_ms=${slowRepository.perCallDelayMs * 5}"
+        )
+    }
+
+    @Test
+    fun `refreshAfterOrderChanged baseline keeps post-submit refresh parallel`() = runTest(testDispatcher.scheduler) {
+        val vm = createViewModel()
+
+        advanceUntilIdle() // settle init work first
+
+        val beforeSummaryCalls = slowRepository.summaryCalls
+        val beforeGrossCalls = slowRepository.grossCalls
+        val beforeTodayCalls = slowRepository.todayIncomeCalls
+        val beforeUnpaidCalls = slowRepository.unpaidCalls
+        val beforeAllCalls = slowRepository.allIncomeCalls
+
+        val startedAt = currentTime
+        vm.refreshAfterOrderChanged()
+
+        val elapsedMs = currentTime - startedAt
+        assertEquals(1_000L, elapsedMs)
+        assertEquals(beforeSummaryCalls + 1, slowRepository.summaryCalls)
+        assertEquals(beforeGrossCalls + 1, slowRepository.grossCalls)
+        assertEquals(beforeTodayCalls + 1, slowRepository.todayIncomeCalls)
+        assertEquals(beforeUnpaidCalls + 1, slowRepository.unpaidCalls)
+        assertEquals(beforeAllCalls + 1, slowRepository.allIncomeCalls)
+        assertFalse(vm.uiState.value.isRefreshing)
+
+        println(
+            "PERF_BASELINE owner=HomeViewModel method=refreshAfterOrderChanged " +
+                "virtual_elapsed_ms=$elapsedMs per_call_delay_ms=${slowRepository.perCallDelayMs} " +
+                "sequential_equivalent_ms=${slowRepository.perCallDelayMs * 5}"
+        )
+    }
+
+    private fun createViewModel(): HomeViewModel {
+        return HomeViewModel(
+            summaryUseCase = ReadSpreadsheetDataUseCase(slowRepository),
+            grossUseCase = ReadGrossDataUseCase(slowRepository),
+            readIncomeUseCase = ReadIncomeTransactionUseCase(slowRepository),
+            userUseCase = mockUserUseCase,
+            observeReminderSettingsUseCase = mockObserveReminderSettingsUseCase,
+            observeReminderLocalStatesUseCase = mockObserveReminderLocalStatesUseCase,
+            evaluateReminderCandidatesUseCase = EvaluateReminderCandidatesUseCase()
+        )
+    }
+
+    private class SlowGoogleSheetRepository(
+        val perCallDelayMs: Long
+    ) : GoogleSheetRepository {
+
+        var summaryCalls: Int = 0
+        var grossCalls: Int = 0
+        var todayIncomeCalls: Int = 0
+        var unpaidCalls: Int = 0
+        var allIncomeCalls: Int = 0
+
+        override suspend fun readSummaryTransaction(): Resource<List<SpreadsheetData>> {
+            summaryCalls++
+            delay(perCallDelayMs)
+            return Resource.Success(listOf(SpreadsheetData("ReadyToPickup Status", "1")))
+        }
+
+        override suspend fun readGrossData(): Resource<List<GrossData>> {
+            grossCalls++
+            delay(perCallDelayMs)
+            return Resource.Success(listOf(GrossData("march", "Rp7000", "1", "Rp0")))
+        }
+
+        override suspend fun readIncomeTransaction(
+            filter: FILTER,
+            rangeDate: RangeDate?
+        ): Resource<List<TransactionData>> {
+            delay(perCallDelayMs)
+            return when (filter) {
+                FILTER.TODAY_TRANSACTION_ONLY -> {
+                    todayIncomeCalls++
+                    Resource.Success(emptyList())
+                }
+
+                FILTER.SHOW_UNPAID_DATA -> {
+                    unpaidCalls++
+                    Resource.Success(emptyList())
+                }
+
+                FILTER.SHOW_ALL_DATA -> {
+                    allIncomeCalls++
+                    Resource.Success(emptyList())
+                }
+
+                else -> Resource.Success(emptyList())
+            }
+        }
+
+        override suspend fun readPackageData(): Resource<List<PackageData>> = unsupported()
+        override suspend fun addPackage(packageData: PackageData): Resource<Boolean> = unsupported()
+        override suspend fun updatePackage(packageData: PackageData): Resource<Boolean> = unsupported()
+        override suspend fun deletePackage(sheetRowIndex: Int): Resource<Boolean> = unsupported()
+        override suspend fun readOtherPackage(): Resource<List<String>> = unsupported()
+        override suspend fun getLastOrderId(): Resource<String> = unsupported()
+        override suspend fun addOrder(order: OrderData): Resource<Boolean> = unsupported()
+        override suspend fun getOrderById(orderId: String): Resource<TransactionData> = unsupported()
+        override suspend fun updateOrder(order: OrderData): Resource<Boolean> = unsupported()
+        override suspend fun deleteOrder(orderId: String): Resource<Boolean> = unsupported()
+        override suspend fun readOutcomeTransaction(): Resource<List<OutcomeData>> = unsupported()
+        override suspend fun addOutcome(outcome: OutcomeData): Resource<Boolean> = unsupported()
+        override suspend fun getLastOutcomeId(): Resource<String> = unsupported()
+        override suspend fun updateOutcome(outcome: OutcomeData): Resource<Boolean> = unsupported()
+        override suspend fun getOutcomeById(outcomeId: String): Resource<OutcomeData> = unsupported()
+        override suspend fun deleteOutcome(outcomeId: String): Resource<Boolean> = unsupported()
+
+        @Suppress("UNCHECKED_CAST")
+        private fun <T> unsupported(): T {
+            throw UnsupportedOperationException("This baseline fake only supports Home refresh reads.")
+        }
+    }
+}

--- a/app/src/test/java/com/raylabs/laundryhub/ui/spreadsheet/SpreadsheetSetupViewModelTest.kt
+++ b/app/src/test/java/com/raylabs/laundryhub/ui/spreadsheet/SpreadsheetSetupViewModelTest.kt
@@ -236,10 +236,10 @@ class SpreadsheetSetupViewModelTest {
         }
 
     @Test
-    fun `validateAndContinue keeps request access hidden when access token is unavailable`() =
+    fun `validateAndContinue asks to reconnect when google sheets access expired`() =
         runTest {
             whenever(validateSpreadsheetUseCase.invoke(INPUT_URL)).thenReturn(
-                Resource.Error("Google Sheets access token is unavailable for user@example.com")
+                Resource.Error(GSheetRepositoryErrorHandling.AUTHORIZATION_RECONNECT_REQUIRED_MESSAGE)
             )
 
             val viewModel = createViewModel()
@@ -248,9 +248,9 @@ class SpreadsheetSetupViewModelTest {
             advanceUntilIdle()
 
             val state = viewModel.uiState.value
-            assertFalse(state.showRequestAccess)
+            assertTrue(state.showRequestAccess)
             assertEquals(
-                "Google Sheets access token is unavailable for user@example.com",
+                "Google Sheets access expired. Grant access again to continue.",
                 state.errorMessage
             )
         }

--- a/docs/core/auth/README.md
+++ b/docs/core/auth/README.md
@@ -1,7 +1,7 @@
 # Core Auth
 
 Status: active living brief
-Last updated: 2026-04-04
+Last updated: 2026-04-23
 Primary area: `core/auth`, `core/firebase`, `ui/onboarding`, `ui/spreadsheet`
 
 ## Goal
@@ -26,6 +26,9 @@ Keep Google sign-in, Sheets authorization, and Firebase runtime dependencies ali
 - authorization no longer forces a synthetic `Account(email, "com.google")` into `AuthorizationRequest`
 - Play Services now decides whether it can reuse a saved account or needs to show a resolution flow
 - Google Sheets and Drive capability checks now send a bearer token returned by `AuthorizationClient`, instead of using `GoogleAccountCredential`
+- access tokens are no longer treated as a long-lived in-memory session cache
+- every token request now asks `AuthorizationClient` again so spreadsheet-backed screens do not blindly reuse a stale bearer token
+- repository error handling now treats Google API `401 Unauthorized` and invalid-credential responses as a reconnect-required auth state instead of leaking raw backend text into the UI
 
 ## Important Decisions
 
@@ -53,6 +56,21 @@ These logs capture:
 - whether `AuthorizationClient` returned scopes directly or required a resolution flow
 - whether an access token is present before the app builds the Sheets client
 - full exceptions from the app side when sign-in or Sheets grant fails
+
+### Stale-token protection
+
+The spreadsheet-backed parts of the app such as Home, History, Outcome, Inventory, and validation all share the same Sheets/Drive authorization path.
+
+Recent rollout feedback exposed a weak point:
+
+- the app could previously cache a Sheets bearer token in memory and keep trusting it
+- when that token became stale, spreadsheet reads could fail with raw `401 Unauthorized` messages even though the user was still signed into Firebase
+
+The current rule is intentionally simpler and safer:
+
+- do not trust an old in-memory Sheets bearer token as the source of truth
+- ask Play Services for authorization again whenever the app needs a token
+- map invalid-credential failures to a reconnect-required user path instead of showing backend details directly
 
 ### Runtime dependency alignment
 
@@ -88,7 +106,20 @@ These commands passed across the auth/runtime updates:
 ./gradlew testDebugUnitTest
 ```
 
+Additional verification for the stale-token recovery update:
+
+```bash
+./gradlew testDebugUnitTest --tests com.raylabs.laundryhub.core.data.service.GoogleSheetsAuthorizationManagerImplTest --tests com.raylabs.laundryhub.core.data.repository.GSheetRepositoryErrorHandlingTest --tests com.raylabs.laundryhub.ui.spreadsheet.SpreadsheetSetupViewModelTest
+./gradlew testDebugUnitTest
+```
+
 ## Follow-Up Notes
 
 - upgrade Kotlin/AGP/toolchain before moving to a newer Firebase BoM line
 - consider an explicit revoke or disconnect flow for Google Sheets authorization
+- do a real release smoke test on spreadsheet-backed screens after shipping auth changes:
+  - Home
+  - History
+  - Outcome
+  - Inventory
+  - Spreadsheet setup validation

--- a/docs/core/performance/README.md
+++ b/docs/core/performance/README.md
@@ -1,0 +1,387 @@
+# Core Performance
+
+Status: active living brief
+Last updated: 2026-04-26 09:34 WIB
+Primary area: `core/performance`, `ui/order`
+
+## Goal
+
+Keep LaundryHub performance discussions grounded in a repeatable baseline instead of subjective feel.
+
+This brief is the source of truth for:
+
+- what we measure
+- which user journey we treat as the first baseline
+- how we record results
+- how we classify the app as `fast`, `acceptable`, or `slow`
+
+## Current Scope
+
+The first tracked baseline should start from the full `Tambah Order` flow, not only from opening the entry sheet.
+
+Initial journey to measure:
+
+1. Launch app in `release` build.
+2. Wait until Home is interactive.
+3. Open the `Order` / `Tambah Order` entry flow.
+4. Fill the minimum valid order data.
+5. Submit the order.
+6. Wait until the success state is visible.
+7. Confirm the new order is reflected in the `Pending Order` section on Home.
+
+This first baseline is intentionally practical.
+
+Reason:
+
+- it is a high-frequency flow
+- it covers both UI entry speed and action-completion speed
+- it also covers the follow-up refresh path that users actually care about after submit
+- it is easier to discuss with product and QA because the result is user-facing end to end
+- it gives us a stronger first benchmark before adding wider app journeys
+
+## Baseline Rules
+
+- Always measure from a `release` build.
+- Prefer one repeatable mid-range Android device as the main local baseline device.
+- Compare like-for-like:
+  - same device
+  - same build type
+  - same scenario
+- Record the exact timestamp with date and time, not date only.
+- Use median results as the baseline reference, not the fastest run.
+
+## Classification Rubric
+
+Use this practical rubric for LaundryHub until real benchmark data suggests we should tighten it.
+
+- `fast`
+  - cold start around `< 1.2s`
+  - warm start around `< 700ms`
+  - no frozen frames
+  - tap to visible response feels almost immediate
+- `acceptable`
+  - cold start around `1.2s - 2.0s`
+  - warm start around `700ms - 1.2s`
+  - no frozen frames
+  - only minor occasional jank
+- `slow`
+  - cold start around `> 2.0s`
+  - repeated visible jank
+  - delayed tap feedback
+  - any frozen-frame behavior
+
+## Recording Format
+
+Every baseline entry should include a timestamp with time, for example:
+
+- `2026-04-24 21:45 WIB`
+
+Recommended fields for each run:
+
+- `captured_at`
+- `app_version`
+- `git_commit`
+- `device`
+- `android_version`
+- `build_type`
+- `scenario`
+- `time_to_initial_display_ms`
+- `time_to_full_display_ms`
+- `submit_to_success_ms`
+- `submit_to_pending_order_refresh_ms`
+- `jank_notes`
+- `frozen_frames`
+- `verdict`
+- `notes`
+
+## First Baseline Table
+
+Use this table for the first real recorded measurements of the full `Tambah Order` flow.
+
+| Captured At | Device | Android | Build | Scenario | TTI Display | TTF Display | Submit To Success | Submit To Pending Refresh | Frozen Frames | Verdict | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `YYYY-MM-DD HH:mm WIB` | `<DEVICE>` | `<ANDROID_VERSION>` | `release` | `Home -> Open Tambah Order -> Submit Success -> Pending Order Updated` | `<TTI_MS>` | `<TTF_MS>` | `<SUBMIT_SUCCESS_MS>` | `<SUBMIT_PENDING_REFRESH_MS>` | `<COUNT>` | `<fast/acceptable/slow>` | `<NOTES>` |
+
+## Planned Next Step
+
+For now, keep the first baseline manual and lightweight.
+
+After the first real measurements are recorded, expand to:
+
+- `Cold start -> Home`
+- `Open Spreadsheet Setup`
+- `Tap Validate & Continue`
+
+## Manual Baseline Prerequisites
+
+The first local baseline run assumes the device is already ready to land on Home.
+
+Required preconditions:
+
+- the app is already signed in
+- spreadsheet setup is already completed
+- the main shell opens to Home instead of onboarding or setup
+- the benchmark device should be a real device when possible, not an emulator
+
+The first baseline flow intentionally uses the minimum valid order input:
+
+- customer name
+- price
+- existing default package selection
+- existing default payment method selection
+
+Phone number is intentionally left blank so the flow stays inside LaundryHub and does not branch into WhatsApp after submit.
+
+## How To Capture The First Baseline
+
+Use a real device when possible and keep the flow practical.
+
+Recommended run steps:
+
+- install and open the `release` build
+- make sure LaundryHub lands directly on Home
+- create one real benchmark order with a unique customer name
+- measure:
+  - app launch to Home interactive
+  - open `Tambah Order`
+  - submit success
+  - pending order refresh visibility
+
+Useful quick checks before capturing:
+
+- `adb devices -l`
+- confirm LaundryHub opens straight to Home on the target device
+- confirm spreadsheet setup is already valid on that device
+- confirm the device is allowed to create a real benchmark order entry in the connected spreadsheet
+
+## Debug Diagnostics
+
+For local debugging, LaundryHub now includes `LeakCanary` as a `debugImplementation` dependency only.
+
+Current intent:
+
+- catch obvious Activity, Fragment, View, or Compose-hosting leaks while iterating locally
+- keep the leak detector fully out of release builds
+- use it as a debugging aid, not as the main source of truth for overall app speed
+
+Practical notes:
+
+- no extra app wiring is required for the default LeakCanary setup
+- leak reports should appear through the standard LeakCanary notification flow in debug builds
+- when needed, local logs can be filtered with `LeakCanary` in Logcat
+
+This is intentionally separate from the main performance baseline.
+
+Reason:
+
+- `LeakCanary` helps answer whether the app is leaking memory
+- it does not replace startup, jank, or end-to-end flow timing checks
+- it is still useful because memory leaks often make a screen feel progressively heavier over time
+
+## Macrobenchmark Baseline
+
+LaundryHub now has a focused `:macrobenchmark` module again, but the scope stays intentionally narrow.
+
+Current formal flow:
+
+- `Home -> Open Add Order -> Submit -> Pending Order updated`
+
+What this benchmark is for:
+
+- measure the user-visible order flow on a real Android device
+- keep the setup aligned with Android Macrobenchmark best practice instead of ad-hoc timing only
+- give us a repeatable baseline before we optimize the submit path
+
+Current benchmark file:
+
+- `macrobenchmark/src/main/java/com/raylabs/laundryhub/macrobenchmark/AddOrderFlowBenchmark.kt`
+
+Important prerequisites:
+
+- use a real device when possible
+- keep the device already signed in and already connected to a valid spreadsheet
+- prefer a dedicated spreadsheet for benchmarking, because this flow creates real orders and does not auto-clean them yet
+- keep the benchmark scope limited to the add-order flow before expanding to other screens
+
+Recommended command:
+
+- `./gradlew :macrobenchmark:connectedBenchmarkAndroidTest --no-daemon`
+
+Useful log filter:
+
+- `adb logcat -s AddOrderFlowBenchmark`
+
+Expected benchmark logs:
+
+- `BENCHMARK_ITERATION ...`
+- `BENCHMARK_SUMMARY ...`
+
+The benchmark currently logs these flow timings per iteration:
+
+- `open_add_order_ms`
+- `submit_to_success_ms`
+- `success_to_pending_ms`
+- `total_flow_ms`
+
+These logs are intended to populate the same `Baseline | Current | Delta` table after the first successful device capture.
+
+### Captured Device Baseline
+
+First successful real-device Macrobenchmark capture:
+
+- captured at: `2026-04-26 01:26 WIB`
+- device: `SM_S931B`
+- Android: `16`
+- build: `benchmark`
+- scenario: `Home -> Open Add Order -> Submit -> Pending Order updated`
+
+Current flow baseline from `BENCHMARK_SUMMARY`:
+
+- `open_add_order_ms_median=661`
+- `submit_to_success_ms_median=3633`
+- `success_to_pending_ms_median=3926`
+- `total_flow_ms_median=13412`
+
+Current frame metrics from AndroidX Benchmark output:
+
+- `frameCount=528`
+- `frameDurationCpuMs P50=2.9`
+- `frameDurationCpuMs P90=4.4`
+- `frameDurationCpuMs P95=5.5`
+- `frameDurationCpuMs P99=8.7`
+- `frameOverrunMs P50=-2.9`
+- `frameOverrunMs P90=0.5`
+- `frameOverrunMs P95=0.7`
+- `frameOverrunMs P99=4.2`
+
+Practical reading:
+
+- the add-order flow is now measurable end to end on a real device
+- submit-to-success and pending-refresh are both in the multi-second range, which supports the earlier feeling that the flow is functionally smooth but still network-heavy
+- use these values as the first comparison point before changing submit refresh orchestration or local caching strategy
+
+## Post-Submit Refresh Refactor
+
+The first optimization pass keeps the data model unchanged and focuses only on orchestration.
+
+What changed:
+
+- `HomeViewModel` now owns post-mutation refresh methods:
+  - `refreshAfterOrderChanged()`
+  - `refreshAfterOutcomeChanged()`
+- order submit/update no longer waits for `fetchOrder`, `fetchTodayIncome`, `fetchSummary`, and `fetchGross` sequentially before closing the sheet
+- the fixed `500 ms` post-submit delay was removed from the order sheet flow
+- the sheet can dismiss and show submit success after the order write succeeds, while Home refresh runs in the background
+- Home refresh still updates Pending Orders, Today Income, Summary, Gross, and reminder discovery through the same source-of-truth fetch methods
+
+Local virtual-time guard:
+
+- `refreshAfterOrderChanged()` with `1000 ms` artificial delay per fetch completes in `1000 ms`
+- the same work would take `5000 ms` if the five Home refresh sections were accidentally made sequential
+
+Latest real-device rerun after the refactor:
+
+- captured at: `2026-04-26 09:34 WIB`
+- device: `SM_S931B`
+- Android: `16`
+- build: `benchmark`
+- scenario: `Home -> Open Add Order -> Submit -> Pending Order updated`
+
+Flow timing comparison:
+
+| Metric | Before refactor | After refactor | Delta | Reading |
+| --- | --- | --- | --- | --- |
+| `open_add_order_ms_median` | `661` | `652` | `-9 ms` | effectively unchanged |
+| `submit_to_success_ms_median` | `3633` | `1245` | `-2388 ms` | major UX win; success feedback arrives much sooner |
+| `success_to_pending_ms_median` | `3926` | `4655` | `+729 ms` | pending refresh still waits on live Sheets data and became the remaining bottleneck |
+| `total_flow_ms_median` | `13412` | `11944` | `-1468 ms` | modest end-to-end improvement; perceived submit speed should feel meaningfully better |
+
+Frame metrics after the refactor:
+
+- `frameCount=423`
+- `frameDurationCpuMs P50=4.1`
+- `frameDurationCpuMs P90=6.4`
+- `frameDurationCpuMs P95=7.5`
+- `frameDurationCpuMs P99=10.3`
+- `frameOverrunMs P50=-0.8`
+- `frameOverrunMs P90=2.3`
+- `frameOverrunMs P95=4.0`
+- `frameOverrunMs P99=8.3`
+
+Benchmark verifier note:
+
+- pending-order verification still prefers filtering by the pending search field
+- if the search field does not appear after the search button is tapped, the benchmark now falls back to scanning for `Order #<id>`
+- this keeps the benchmark focused on the real product result instead of failing on one brittle UIAutomator interaction
+
+## Local JVM Baselines
+
+There are now two local, no-device baseline tests that can be run through normal JVM unit tests.
+
+Current local baselines:
+
+- `app/src/test/java/com/raylabs/laundryhub/core/data/repository/GoogleSheetRepositoryImplPerformanceBaselineTest.kt`
+- `app/src/test/java/com/raylabs/laundryhub/ui/home/HomeViewModelPerformanceBaselineTest.kt`
+
+What they cover:
+
+- repository-side cost for mapping, filtering, and sorting a large `income` sheet when reading `Pending Order`
+- virtual-time confirmation that `HomeViewModel.refreshAllData()` still behaves like a parallel refresh instead of silently becoming sequential
+
+These are intentionally local baselines, not UX truth.
+
+Reason:
+
+- they can run without a connected Android device
+- they are stable enough to compare before and after refactors
+- they help catch logic-side performance regressions even when real UI timing is not available
+
+Recommended command:
+
+- `./gradlew testDebugUnitTest --tests com.raylabs.laundryhub.core.data.repository.GoogleSheetRepositoryImplPerformanceBaselineTest --tests com.raylabs.laundryhub.ui.home.HomeViewModelPerformanceBaselineTest --no-daemon`
+- `./scripts/run_local_perf_baseline.sh`
+
+Expected output:
+
+- `PERF_BASELINE repository=GoogleSheetRepositoryImpl ...`
+- `PERF_BASELINE owner=HomeViewModel method=refreshAllData ...`
+- `PERF_BASELINE owner=HomeViewModel method=refreshAfterOrderChanged ...`
+
+Tracked comparison table:
+
+| Metric | Baseline | Current | Delta | Interpretation |
+| --- | --- | --- | --- | --- |
+| `GoogleSheetRepositoryImpl.readIncomeTransaction(FILTER.SHOW_UNPAID_DATA)` with `5000` rows | `221 ms` | `230 ms` | `+9 ms` | current local transform/filter cost is still acceptable; this small movement is normal local-test noise |
+| `HomeViewModel.refreshAllData()` virtual-time orchestration with `1000 ms` per fetch | `1000 ms` | `1000 ms` | `0 ms` | refresh orchestration is still parallel, not sequential |
+| `HomeViewModel.refreshAfterOrderChanged()` virtual-time orchestration with `1000 ms` per fetch | `5000 ms sequential equivalent` | `1000 ms` | `-4000 ms` | post-order Home refresh now uses the shared parallel orchestration instead of the old sequential caller path |
+
+Initial capture:
+
+| Captured At | Metric | Result |
+| --- | --- | --- |
+| `2026-04-25 07:13 WIB` | `GoogleSheetRepositoryImpl.readIncomeTransaction(FILTER.SHOW_UNPAID_DATA)` with `5000` rows | `221 ms` |
+| `2026-04-25 07:13 WIB` | `HomeViewModel.refreshAllData()` virtual-time orchestration with `1000 ms` per fetch | `1000 ms` total, versus `5000 ms` sequential equivalent |
+| `2026-04-26 01:47 WIB` | `GoogleSheetRepositoryImpl.readIncomeTransaction(FILTER.SHOW_UNPAID_DATA)` with `5000` rows | `230 ms` |
+| `2026-04-26 01:47 WIB` | `HomeViewModel.refreshAllData()` virtual-time orchestration with `1000 ms` per fetch | `1000 ms` total, versus `5000 ms` sequential equivalent |
+| `2026-04-26 01:47 WIB` | `HomeViewModel.refreshAfterOrderChanged()` virtual-time orchestration with `1000 ms` per fetch | `1000 ms` total, versus `5000 ms` sequential equivalent |
+
+Update rule:
+
+- keep `Baseline` fixed until we intentionally reset the benchmark generation
+- update `Current` after each meaningful performance-related code change
+- fill `Delta` as `Current - Baseline`
+- if a new local run changes the shape of the benchmark itself, record that in notes before comparing numbers
+
+## Verification
+
+Latest successful verification:
+
+- `./gradlew testDebugUnitTest --tests com.raylabs.laundryhub.ui.home.HomeViewModelTest --tests com.raylabs.laundryhub.ui.home.HomeViewModelPerformanceBaselineTest --no-daemon`
+- `./scripts/run_local_perf_baseline.sh`
+- `./gradlew testDebugUnitTest --no-daemon`
+- `./gradlew :app:assembleBenchmark --no-daemon`
+- `./gradlew :macrobenchmark:assembleBenchmark --no-daemon`
+- `adb install -r app/build/outputs/apk/benchmark/app-benchmark.apk`
+- `adb install -r macrobenchmark/build/outputs/apk/benchmark/macrobenchmark-benchmark.apk`
+- `adb devices -l`
+- `adb shell am instrument -w -e class com.raylabs.laundryhub.macrobenchmark.AddOrderFlowBenchmark com.raylabs.laundryhub.macrobenchmark/androidx.test.runner.AndroidJUnitRunner`

--- a/macrobenchmark/build.gradle
+++ b/macrobenchmark/build.gradle
@@ -1,0 +1,47 @@
+plugins {
+    id 'com.android.test'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace = 'com.raylabs.laundryhub.macrobenchmark'
+    compileSdkVersion 36
+    targetProjectPath = ':app'
+
+    experimentalProperties["android.experimental.self-instrumenting"] = true
+
+    defaultConfig {
+        minSdkVersion 23
+        targetSdk 36
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+    }
+
+    buildTypes {
+        benchmark {
+            debuggable = true
+            signingConfig = signingConfigs.debug
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_18
+        targetCompatibility JavaVersion.VERSION_18
+    }
+
+    kotlinOptions {
+        jvmTarget = "18"
+    }
+}
+
+androidComponents {
+    beforeVariants(selector().all()) { variant ->
+        variant.enable = variant.buildType == "benchmark"
+    }
+}
+
+dependencies {
+    implementation 'androidx.benchmark:benchmark-macro-junit4:1.3.4'
+    implementation 'androidx.test.ext:junit:1.3.0'
+    implementation 'androidx.test:runner:1.6.2'
+    implementation 'androidx.test.uiautomator:uiautomator:2.3.0'
+}

--- a/macrobenchmark/src/main/java/com/raylabs/laundryhub/macrobenchmark/AddOrderFlowBenchmark.kt
+++ b/macrobenchmark/src/main/java/com/raylabs/laundryhub/macrobenchmark/AddOrderFlowBenchmark.kt
@@ -1,0 +1,591 @@
+package com.raylabs.laundryhub.macrobenchmark
+
+import android.os.SystemClock
+import android.util.Log
+import androidx.benchmark.macro.BaselineProfileMode
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.MacrobenchmarkScope
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.BySelector
+import androidx.test.uiautomator.UiObject2
+import androidx.test.uiautomator.Until
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class AddOrderFlowBenchmark {
+
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @Test
+    fun addOrderFlow_updatesPendingOrder() {
+        val openSheetDurations = mutableListOf<Long>()
+        val submitToSuccessDurations = mutableListOf<Long>()
+        val successToPendingDurations = mutableListOf<Long>()
+        val totalFlowDurations = mutableListOf<Long>()
+        var iteration = 0
+
+        benchmarkRule.measureRepeated(
+            packageName = TARGET_PACKAGE,
+            metrics = listOf(FrameTimingMetric()),
+            compilationMode = CompilationMode.Partial(
+                baselineProfileMode = BaselineProfileMode.Disable,
+                warmupIterations = 1
+            ),
+            iterations = 1,
+            setupBlock = {
+                pressHome()
+                launchAppFromShell()
+                ensureHomeReady()
+            }
+        ) {
+            iteration += 1
+
+            val orderName = "bench${SystemClock.elapsedRealtime() % 100000}"
+            val totalStart = SystemClock.elapsedRealtime()
+
+            val openSheetMs = openOrderSheet()
+            selectFirstPackage()
+            fillRequiredFields(orderName = orderName, price = ORDER_PRICE)
+
+            val submitStart = SystemClock.elapsedRealtime()
+            tapObjectCenter(
+                selector = By.desc(ORDER_SUBMIT_BUTTON_DESCRIPTION),
+                debugLabel = ORDER_SUBMIT_BUTTON_DESCRIPTION,
+                timeoutMs = FORM_READY_TIMEOUT_MS
+            )
+
+            val successMessage = waitForObject(
+                By.textContains(ORDER_SUBMIT_SUCCESS_TEXT),
+                SUBMIT_TIMEOUT_MS
+            ).text.orEmpty()
+            val submitToSuccessMs = SystemClock.elapsedRealtime() - submitStart
+            val submittedOrderId = extractSubmittedOrderId(successMessage)
+
+            val pendingWaitStart = SystemClock.elapsedRealtime()
+            waitForPendingOrderVisibility(
+                orderId = submittedOrderId,
+                orderName = orderName
+            )
+            val successToPendingMs = SystemClock.elapsedRealtime() - pendingWaitStart
+
+            val totalFlowMs = SystemClock.elapsedRealtime() - totalStart
+
+            openSheetDurations += openSheetMs
+            submitToSuccessDurations += submitToSuccessMs
+            successToPendingDurations += successToPendingMs
+            totalFlowDurations += totalFlowMs
+
+            Log.i(
+                LOG_TAG,
+                "BENCHMARK_ITERATION iteration=$iteration " +
+                    "open_add_order_ms=$openSheetMs " +
+                    "submit_to_success_ms=$submitToSuccessMs " +
+                    "success_to_pending_ms=$successToPendingMs " +
+                    "total_flow_ms=$totalFlowMs " +
+                    "order_name=$orderName " +
+                    "order_id=$submittedOrderId"
+            )
+        }
+
+        Log.i(
+            LOG_TAG,
+            "BENCHMARK_SUMMARY " +
+                "open_add_order_ms_median=${openSheetDurations.median()} " +
+                "submit_to_success_ms_median=${submitToSuccessDurations.median()} " +
+                "success_to_pending_ms_median=${successToPendingDurations.median()} " +
+                "total_flow_ms_median=${totalFlowDurations.median()}"
+        )
+    }
+
+    private fun MacrobenchmarkScope.openOrderSheet(): Long {
+        val start = SystemClock.elapsedRealtime()
+        tapObjectCenter(
+            selector = By.desc(ORDER_NAV_DESCRIPTION),
+            debugLabel = ORDER_NAV_DESCRIPTION,
+            timeoutMs = HOME_LOAD_TIMEOUT_MS
+        )
+        waitForObject(By.desc(ORDER_SHEET_DESCRIPTION), SHEET_LOAD_TIMEOUT_MS)
+        return SystemClock.elapsedRealtime() - start
+    }
+
+    private fun MacrobenchmarkScope.launchAppFromShell() {
+        device.executeShellCommand(
+            "am start -W -a android.intent.action.MAIN " +
+                "-c android.intent.category.LAUNCHER " +
+                "$TARGET_PACKAGE/.ui.MainActivity"
+        )
+        device.waitForIdle()
+    }
+
+    private fun MacrobenchmarkScope.ensureHomeReady() {
+        when (waitForStartupState()) {
+            StartupState.HOME -> return
+
+            StartupState.SPREADSHEET_SETUP -> {
+                Log.i(LOG_TAG, "Spreadsheet setup screen detected before benchmark flow")
+
+                val connectSheetsButton = waitForOptionalObject(
+                    By.text(CONNECT_GOOGLE_SHEETS_TEXT),
+                    SHORT_WAIT_TIMEOUT_MS
+                )
+                check(connectSheetsButton == null) {
+                    "Benchmark device still needs Google Sheets access. Open the app once and grant Sheets access before rerunning Macrobenchmark."
+                }
+
+                val validateButton = waitForOptionalObject(
+                    By.text(VALIDATE_AND_CONTINUE_TEXT),
+                    SHORT_WAIT_TIMEOUT_MS
+                )
+                if (validateButton != null && validateButton.isEnabled) {
+                    validateButton.click()
+                    device.waitForIdle()
+                }
+
+                waitForHomeReady()
+            }
+
+            StartupState.ONBOARDING -> error(
+                "Benchmark app reached onboarding. Sign in once on this benchmark build/device before rerunning Macrobenchmark."
+            )
+
+            StartupState.UNKNOWN -> {
+                val windowHierarchy = dumpWindowHierarchy()
+                error(
+                    "App did not reach Home, Spreadsheet Setup, or onboarding. " +
+                        "Window markers=${summarizeWindowMarkers(windowHierarchy)}"
+                )
+            }
+        }
+    }
+
+    private fun MacrobenchmarkScope.waitForStartupState(): StartupState {
+        val deadline = SystemClock.elapsedRealtime() + STARTUP_STATE_TIMEOUT_MS
+        var lastObservedState = StartupState.UNKNOWN
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (isHomeVisible()) {
+                return StartupState.HOME
+            }
+            if (device.hasObject(By.text(SPREADSHEET_SETUP_TITLE))) {
+                lastObservedState = StartupState.SPREADSHEET_SETUP
+            }
+            if (device.hasObject(By.text(LOGIN_WITH_GOOGLE_TEXT))) {
+                lastObservedState = StartupState.ONBOARDING
+            }
+
+            device.waitForIdle()
+            SystemClock.sleep(500)
+        }
+
+        return lastObservedState
+    }
+
+    private fun MacrobenchmarkScope.dumpWindowHierarchy(): String {
+        return device.executeShellCommand(
+            "uiautomator dump /sdcard/laundryhub-benchmark-window.xml >/dev/null; " +
+                "cat /sdcard/laundryhub-benchmark-window.xml"
+        )
+    }
+
+    private fun summarizeWindowMarkers(windowHierarchy: String): String {
+        val markers = buildList {
+            if (windowHierarchy.contains(TODAY_ACTIVITY_TITLE) || windowHierarchy.contains(PENDING_ORDERS_TITLE)) {
+                add("home")
+            }
+            if (windowHierarchy.contains("content-desc=\"$ORDER_NAV_DESCRIPTION\"")) {
+                add("app_shell")
+            }
+            if (windowHierarchy.contains(SPREADSHEET_SETUP_TITLE)) add("spreadsheet_setup")
+            if (windowHierarchy.contains(LOGIN_WITH_GOOGLE_TEXT)) add("onboarding")
+            if (windowHierarchy.contains(VALIDATE_AND_CONTINUE_TEXT)) add("validate_button")
+            if (windowHierarchy.contains(CONNECT_GOOGLE_SHEETS_TEXT)) add("connect_sheets")
+        }
+        return if (markers.isEmpty()) "none" else markers.joinToString()
+    }
+
+    private fun MacrobenchmarkScope.waitForHomeReady() {
+        val deadline = SystemClock.elapsedRealtime() + HOME_LOAD_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (isHomeVisible()) return
+            device.waitForIdle()
+            SystemClock.sleep(250)
+        }
+
+        error("Timed out waiting for Home markers to become visible")
+    }
+
+    private fun MacrobenchmarkScope.isHomeVisible(): Boolean {
+        return device.hasObject(By.text(TODAY_ACTIVITY_TITLE)) ||
+            device.hasObject(By.text(PENDING_ORDERS_TITLE)) ||
+            device.hasObject(By.desc(ORDER_NAV_DESCRIPTION))
+    }
+
+    private fun MacrobenchmarkScope.fillRequiredFields(orderName: String, price: String) {
+        focusFieldAndInputText(
+            selectors = listOf(
+                By.desc(ORDER_NAME_FIELD_DESCRIPTION),
+                By.text(NAME_LABEL)
+            ),
+            value = orderName,
+            debugLabel = ORDER_NAME_FIELD_DESCRIPTION
+        )
+        device.pressBack()
+        device.waitForIdle()
+        SystemClock.sleep(300)
+        ensureFieldVisible(
+            selectors = listOf(
+                By.desc(ORDER_PRICE_FIELD_DESCRIPTION),
+                By.text(PRICE_LABEL)
+            ),
+            debugLabel = ORDER_PRICE_FIELD_DESCRIPTION
+        )
+        focusFieldAndInputText(
+            selectors = listOf(
+                By.desc(ORDER_PRICE_FIELD_DESCRIPTION),
+                By.text(PRICE_LABEL)
+            ),
+            value = price,
+            debugLabel = ORDER_PRICE_FIELD_DESCRIPTION
+        )
+        device.pressBack()
+        device.waitForIdle()
+    }
+
+    private fun MacrobenchmarkScope.selectFirstPackage() {
+        tapObjectCenter(
+            selector = firstPackageSelector(),
+            debugLabel = "first package option",
+            timeoutMs = FORM_READY_TIMEOUT_MS
+        )
+        device.waitForIdle()
+    }
+
+    private fun MacrobenchmarkScope.tapObjectCenter(
+        selector: BySelector,
+        debugLabel: String,
+        timeoutMs: Long
+    ) {
+        val current = waitForObject(selector, timeoutMs)
+        val bounds = current.visibleBounds
+        check(device.click(bounds.centerX(), bounds.centerY())) {
+            "Failed to tap object center for $debugLabel at $bounds"
+        }
+        device.waitForIdle()
+    }
+
+    private fun MacrobenchmarkScope.focusFieldAndInputText(
+        selectors: List<BySelector>,
+        value: String,
+        debugLabel: String
+    ) {
+        val field = waitForAnyObject(selectors, FORM_READY_TIMEOUT_MS)
+        inputTextIntoObject(field, value, debugLabel)
+    }
+
+    private fun MacrobenchmarkScope.inputTextIntoObject(
+        field: UiObject2,
+        value: String,
+        debugLabel: String
+    ) {
+        val bounds = field.visibleBounds
+        check(device.click(bounds.centerX(), bounds.centerY())) {
+            "Failed to tap field for $debugLabel at $bounds"
+        }
+        device.executeShellCommand("input text ${escapeForShellInput(value)}")
+        device.waitForIdle()
+        SystemClock.sleep(300)
+    }
+
+    private fun MacrobenchmarkScope.ensureFieldVisible(
+        selectors: List<BySelector>,
+        debugLabel: String
+    ) {
+        val deadline = SystemClock.elapsedRealtime() + FORM_READY_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val field = waitForOptionalAnyObject(selectors, SHORT_WAIT_TIMEOUT_MS)
+            if (field != null && !field.visibleBounds.isEmpty) {
+                return
+            }
+
+            device.swipe(
+                (device.displayWidth * 0.88f).toInt(),
+                (device.displayHeight * 0.82f).toInt(),
+                (device.displayWidth * 0.88f).toInt(),
+                (device.displayHeight * 0.42f).toInt(),
+                24
+            )
+            device.waitForIdle()
+            SystemClock.sleep(400)
+        }
+
+        error("Timed out waiting for field to become visible: $debugLabel")
+    }
+
+    private fun MacrobenchmarkScope.waitForPendingOrderVisibility(
+        orderId: String,
+        orderName: String
+    ) {
+        ensurePendingOrdersVisible()
+
+        if (filterPendingOrdersByName(orderName)) {
+            val displayName = orderName.replaceFirstChar { firstChar ->
+                firstChar.uppercase()
+            }
+            waitForSingleFilteredPendingResult(displayName)
+            return
+        }
+
+        waitForPendingOrderLabel(orderId)
+    }
+
+    private fun MacrobenchmarkScope.filterPendingOrdersByName(orderName: String): Boolean {
+        if (!openPendingOrderSearch()) {
+            return false
+        }
+
+        val searchField = waitForOptionalAnyObject(
+            selectors = listOf(
+                By.desc(PENDING_ORDER_SEARCH_FIELD_DESCRIPTION),
+                By.clazz("android.widget.EditText"),
+                By.text(SEARCH_CUSTOMER_PLACEHOLDER)
+            ),
+            timeoutMs = SHORT_WAIT_TIMEOUT_MS
+        )
+        if (searchField == null || searchField.visibleBounds.isEmpty) {
+            Log.i(LOG_TAG, "Pending search field did not appear; falling back to order id scan")
+            device.pressBack()
+            device.waitForIdle()
+            return false
+        }
+
+        inputTextIntoObject(
+            field = searchField,
+            value = orderName,
+            debugLabel = PENDING_ORDER_SEARCH_LABEL
+        )
+        device.pressBack()
+        device.waitForIdle()
+        return true
+    }
+
+    private fun MacrobenchmarkScope.waitForPendingOrderLabel(orderId: String) {
+        val orderLabel = "Order #$orderId"
+        val deadline = SystemClock.elapsedRealtime() + PENDING_UPDATE_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (device.hasObject(By.text(orderLabel))) {
+                return
+            }
+
+            device.swipe(
+                device.displayWidth / 2,
+                (device.displayHeight * 0.78f).toInt(),
+                device.displayWidth / 2,
+                (device.displayHeight * 0.34f).toInt(),
+                24
+            )
+            device.waitForIdle()
+            SystemClock.sleep(400)
+        }
+
+        error("Timed out waiting for pending order card to show $orderLabel")
+    }
+
+    private fun MacrobenchmarkScope.openPendingOrderSearch(): Boolean {
+        repeat(6) {
+            val searchButton = waitForOptionalObject(
+                selector = By.desc(OPEN_SEARCH_DESCRIPTION),
+                timeoutMs = SHORT_WAIT_TIMEOUT_MS
+            )
+            if (searchButton != null) {
+                val bounds = searchButton.visibleBounds
+                check(device.click(bounds.centerX(), bounds.centerY())) {
+                    "Failed to tap Pending Order search button at $bounds"
+                }
+                device.waitForIdle()
+                return true
+            }
+
+            device.swipe(
+                device.displayWidth / 2,
+                (device.displayHeight * 0.34f).toInt(),
+                device.displayWidth / 2,
+                (device.displayHeight * 0.74f).toInt(),
+                24
+            )
+            device.waitForIdle()
+            SystemClock.sleep(400)
+        }
+
+        return false
+    }
+
+    private fun MacrobenchmarkScope.waitForSingleFilteredPendingResult(displayName: String) {
+        val deadline = SystemClock.elapsedRealtime() + PENDING_UPDATE_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val visibleOrderLabels = device.findObjects(By.textStartsWith(ORDER_LABEL_PREFIX))
+                .count { !it.visibleBounds.isEmpty }
+            val hasDisplayName = device.hasObject(By.text(displayName))
+
+            if (hasDisplayName && visibleOrderLabels == 1) {
+                return
+            }
+
+            device.waitForIdle()
+            SystemClock.sleep(300)
+        }
+
+        error("Timed out waiting for exactly one filtered pending result for $displayName")
+    }
+
+    private fun MacrobenchmarkScope.ensurePendingOrdersVisible() {
+        val deadline = SystemClock.elapsedRealtime() + PENDING_UPDATE_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val hasPendingHeader = device.hasObject(By.text(PENDING_ORDERS_TITLE)) ||
+                device.hasObject(By.desc(OPEN_SEARCH_DESCRIPTION))
+            if (hasPendingHeader) {
+                return
+            }
+
+            device.swipe(
+                device.displayWidth / 2,
+                (device.displayHeight * 0.82f).toInt(),
+                device.displayWidth / 2,
+                (device.displayHeight * 0.42f).toInt(),
+                24
+            )
+            device.waitForIdle()
+            SystemClock.sleep(400)
+        }
+
+        error("Timed out waiting for Pending Orders section to become visible")
+    }
+
+    private fun MacrobenchmarkScope.waitForObject(
+        selector: BySelector,
+        timeoutMs: Long
+    ): UiObject2 {
+        device.wait(Until.hasObject(selector), timeoutMs)
+        return requireNotNull(device.findObject(selector)) {
+            "Timed out waiting for UI object: $selector"
+        }
+    }
+
+    private fun MacrobenchmarkScope.waitForOptionalObject(
+        selector: BySelector,
+        timeoutMs: Long
+    ): UiObject2? {
+        device.wait(Until.hasObject(selector), timeoutMs)
+        return device.findObject(selector)
+    }
+
+    private fun MacrobenchmarkScope.waitForAnyObject(
+        selectors: List<BySelector>,
+        timeoutMs: Long
+    ): UiObject2 {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            selectors.firstNotNullOfOrNull { selector -> device.findObject(selector) }?.let { return it }
+
+            device.waitForIdle()
+            SystemClock.sleep(250)
+        }
+
+        error("Timed out waiting for any UI object in selectors: $selectors")
+    }
+
+    private fun MacrobenchmarkScope.waitForOptionalAnyObject(
+        selectors: List<BySelector>,
+        timeoutMs: Long
+    ): UiObject2? {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            selectors.firstNotNullOfOrNull { selector -> device.findObject(selector) }?.let { return it }
+
+            device.waitForIdle()
+            SystemClock.sleep(250)
+        }
+
+        return null
+    }
+
+    private fun List<Long>.median(): Long {
+        if (isEmpty()) return 0L
+        val sorted = sorted()
+        val middle = sorted.size / 2
+        return if (sorted.size % 2 == 0) {
+            (sorted[middle - 1] + sorted[middle]) / 2
+        } else {
+            sorted[middle]
+        }
+    }
+
+    companion object {
+        private const val TARGET_PACKAGE = "com.raylabs.laundryhub"
+        private const val LOG_TAG = "AddOrderFlowBenchmark"
+        private const val ORDER_PRICE = "8000"
+
+        private const val ORDER_NAV_DESCRIPTION = "Order"
+        private const val ORDER_SHEET_DESCRIPTION = "Order sheet"
+        private const val ORDER_NAME_FIELD_DESCRIPTION = "Order name field"
+        private const val ORDER_PACKAGE_OPTION_DESCRIPTION_PREFIX = "Package option "
+        private const val ORDER_PRICE_FIELD_DESCRIPTION = "Order price field"
+        private const val ORDER_SUBMIT_BUTTON_DESCRIPTION = "Submit order"
+        private const val TODAY_ACTIVITY_TITLE = "Today Activity"
+        private const val PENDING_ORDERS_TITLE = "Pending Orders"
+        private const val ORDER_LABEL_PREFIX = "Order #"
+        private const val OPEN_SEARCH_DESCRIPTION = "Open Search"
+        private const val PENDING_ORDER_SEARCH_LABEL = "Pending order search"
+        private const val PENDING_ORDER_SEARCH_FIELD_DESCRIPTION = "Pending order search field"
+        private const val ORDER_SUBMIT_SUCCESS_TEXT = "submitted successfully."
+        private const val NAME_LABEL = "Name"
+        private const val PRICE_LABEL = "Price"
+        private const val SEARCH_CUSTOMER_PLACEHOLDER = "Search Customer"
+        private const val SPREADSHEET_SETUP_TITLE = "Set Up Your Spreadsheet"
+        private const val VALIDATE_AND_CONTINUE_TEXT = "Validate & Continue"
+        private const val CONNECT_GOOGLE_SHEETS_TEXT = "Connect Google Sheets"
+        private const val LOGIN_WITH_GOOGLE_TEXT = "Login with Google"
+
+        private const val HOME_LOAD_TIMEOUT_MS = 15_000L
+        private const val STARTUP_STATE_TIMEOUT_MS = 30_000L
+        private const val SHEET_LOAD_TIMEOUT_MS = 10_000L
+        private const val FORM_READY_TIMEOUT_MS = 20_000L
+        private const val SUBMIT_TIMEOUT_MS = 45_000L
+        private const val PENDING_UPDATE_TIMEOUT_MS = 45_000L
+        private const val SHORT_WAIT_TIMEOUT_MS = 2_500L
+
+        private fun firstPackageSelector(): BySelector = By.descStartsWith(
+            ORDER_PACKAGE_OPTION_DESCRIPTION_PREFIX
+        )
+
+        private fun extractSubmittedOrderId(successMessage: String): String {
+            val match = Regex("""Order #(\d+)""").find(successMessage)
+            return requireNotNull(match?.groupValues?.getOrNull(1)) {
+                "Unable to parse submitted order id from success message: $successMessage"
+            }
+        }
+
+        private fun escapeForShellInput(value: String): String = buildString {
+            value.forEach { char ->
+                when {
+                    char.isLetterOrDigit() -> append(char)
+                    char == ' ' -> append("%s")
+                    else -> append("\\").append(char)
+                }
+            }
+        }
+    }
+
+    private enum class StartupState {
+        HOME,
+        SPREADSHEET_SETUP,
+        ONBOARDING,
+        UNKNOWN
+    }
+}

--- a/scripts/run_local_perf_baseline.sh
+++ b/scripts/run_local_perf_baseline.sh
@@ -1,0 +1,30 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+export GRADLE_USER_HOME="$ROOT_DIR/.gradle"
+
+./gradlew testDebugUnitTest \
+  --tests com.raylabs.laundryhub.core.data.repository.GoogleSheetRepositoryImplPerformanceBaselineTest \
+  --tests com.raylabs.laundryhub.ui.home.HomeViewModelPerformanceBaselineTest \
+  --no-daemon
+
+REPO_XML="app/build/test-results/testDebugUnitTest/TEST-com.raylabs.laundryhub.core.data.repository.GoogleSheetRepositoryImplPerformanceBaselineTest.xml"
+HOME_XML="app/build/test-results/testDebugUnitTest/TEST-com.raylabs.laundryhub.ui.home.HomeViewModelPerformanceBaselineTest.xml"
+
+repo_elapsed_ms="$(grep -o 'elapsed_ms=[0-9]*' "$REPO_XML" | head -n 1 | cut -d= -f2)"
+home_refresh_elapsed_ms="$(grep 'method=refreshAllData' "$HOME_XML" | grep -o 'virtual_elapsed_ms=[0-9]*' | head -n 1 | cut -d= -f2)"
+home_refresh_sequential_ms="$(grep 'method=refreshAllData' "$HOME_XML" | grep -o 'sequential_equivalent_ms=[0-9]*' | head -n 1 | cut -d= -f2)"
+home_post_order_elapsed_ms="$(grep 'method=refreshAfterOrderChanged' "$HOME_XML" | grep -o 'virtual_elapsed_ms=[0-9]*' | head -n 1 | cut -d= -f2)"
+home_post_order_sequential_ms="$(grep 'method=refreshAfterOrderChanged' "$HOME_XML" | grep -o 'sequential_equivalent_ms=[0-9]*' | head -n 1 | cut -d= -f2)"
+
+captured_at="$(date '+%Y-%m-%d %H:%M %Z')"
+
+echo
+echo "LOCAL_PERF_BASELINE captured_at=$captured_at"
+echo "LOCAL_PERF_BASELINE metric=repository_pending_order_5000_rows elapsed_ms=$repo_elapsed_ms"
+echo "LOCAL_PERF_BASELINE metric=home_refresh_virtual elapsed_ms=$home_refresh_elapsed_ms sequential_equivalent_ms=$home_refresh_sequential_ms"
+echo "LOCAL_PERF_BASELINE metric=home_post_order_refresh_virtual elapsed_ms=$home_post_order_elapsed_ms sequential_equivalent_ms=$home_post_order_sequential_ms"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
 include ':app'
+include ':macrobenchmark'


### PR DESCRIPTION
…ration

This commit introduces a performance benchmarking suite and refactors the home screen's data refresh logic to improve perceived responsiveness after order mutations. It shifts from sequential data fetching to parallel orchestration and removes artificial delays in the UI flow.

### Performance & Benchmarking
- **Macrobenchmark**: Added a new `:macrobenchmark` module with `AddOrderFlowBenchmark` to measure the end-to-end "Add Order" journey on real devices.
- **Local Baselines**: Introduced JVM-based performance tests for `GoogleSheetRepositoryImpl` (large dataset filtering) and `HomeViewModel` (parallel orchestration verification).
- **Optimization**: Refactored `HomeViewModel` to use `refreshAfterOrderChanged()` and `refreshAfterOutcomeChanged()`, enabling concurrent fetching of spreadsheet sections. This reduced "submit to success" latency by ~2.4s in benchmark traces.
- **Instrumentation**: Added `LeakCanary` to debug builds for memory leak detection and introduced a `profileable` manifest for the benchmark build type.

### Architecture & Auth
- **Auth Hardening**: Removed local token caching in `GoogleSheetsAuthorizationManagerImpl` to ensure fresh authorization via Play Services, preventing `401 Unauthorized` errors from stale sessions.
- **Error Handling**: Enhanced `GSheetRepositoryErrorHandling` to map invalid credential responses to a user-friendly "reconnect required" state.
- **Resilience**: Added ProGuard/R8 keep rules for Gson DTOs used in Drive API responses to prevent instantiation errors in minified builds.

### UI/UX
- **Sheet Improvements**: Added vertical scrolling to the `OrderBottomSheet` to support smaller screens and ensured the sheet dismisses immediately after a successful write while data refreshes in the background.
- **Accessibility**: Added `contentDescription` semantics to order fields, package options, and search fields to facilitate both accessibility and UIAutomator-based benchmarking.

### Documentation & Tooling
- **Performance Brief**: Created `docs/core/performance/README.md` to track performance goals, classification rubrics, and historical baseline measurements.
- **Scripts**: Added `run_local_perf_baseline.sh` for quick JVM-based performance verification.
- **CI/CD**: Updated `.gitignore` to exclude Perfetto traces and updated build configurations to support the new benchmark build type.