### PR TITLE
perf: Implement Delete flow benchmark and optimize post-delete UI logic

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,7 +128,8 @@ android {
             includeAndroidResources = true
             returnDefaultValues = true
             all {
-                maxHeapSize = "2g"
+                maxHeapSize = "1g"
+                forkEvery = 50
             }
         }
     }

--- a/app/src/main/java/com/raylabs/laundryhub/ui/LaundryHubStarter.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/LaundryHubStarter.kt
@@ -59,6 +59,7 @@ import com.raylabs.laundryhub.core.domain.model.settings.SpreadsheetConfig
 import com.raylabs.laundryhub.core.reminder.ReminderNotificationConfig
 import com.raylabs.laundryhub.ui.common.navigation.BottomNavItem
 import com.raylabs.laundryhub.ui.common.util.WhatsAppHelper
+import com.raylabs.laundryhub.ui.common.util.showQuickSnackbar
 import com.raylabs.laundryhub.ui.component.rememberInlineAdaptiveBannerAdState
 import com.raylabs.laundryhub.ui.history.HistoryScreenView
 import com.raylabs.laundryhub.ui.home.GrossDetailScreenView
@@ -586,7 +587,7 @@ fun ShowOrderBottomSheet(
                 if (orderId.isNullOrBlank()) {
                     val errorMessage = orderViewModel.uiState.value.lastOrderIdError
                         ?: orderIdUnavailableMessage
-                    snackBarHostState.showSnackbar(errorMessage)
+                    snackBarHostState.showQuickSnackbar(errorMessage)
                     return@launch
                 }
 
@@ -613,10 +614,10 @@ fun ShowOrderBottomSheet(
                         } else {
                             context.getString(R.string.order_submit_success, orderId)
                         }
-                        snackBarHostState.showSnackbar(successMessage)
+                        snackBarHostState.showQuickSnackbar(successMessage)
                     },
                     onError = { errorMessage ->
-                        snackBarHostState.showSnackbar(errorMessage.ifBlank { submitFailedMessage })
+                        snackBarHostState.showQuickSnackbar(errorMessage.ifBlank { submitFailedMessage })
                     }
                 )
             }
@@ -628,12 +629,12 @@ fun ShowOrderBottomSheet(
                     onComplete = {
                         scope.launchOrderChangedRefresh(homeViewModel)
                         dismissSheet()
-                        snackBarHostState.showSnackbar(
+                        snackBarHostState.showQuickSnackbar(
                             context.getString(R.string.order_update_success, uiState.orderID)
                         )
                     },
                     onError = { errorMessage ->
-                        snackBarHostState.showSnackbar(errorMessage.ifBlank { updateFailedMessage })
+                        snackBarHostState.showQuickSnackbar(errorMessage.ifBlank { updateFailedMessage })
                     }
                 )
             }

--- a/app/src/main/java/com/raylabs/laundryhub/ui/common/util/SnackbarUtil.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/common/util/SnackbarUtil.kt
@@ -1,0 +1,24 @@
+package com.raylabs.laundryhub.ui.common.util
+
+import androidx.compose.material.SnackbarDuration
+import androidx.compose.material.SnackbarHostState
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Shows a snackbar that dismisses faster than the default [SnackbarDuration.Short].
+ * Default [SnackbarDuration.Short] is usually 4 seconds.
+ * This function defaults to 1.5 seconds.
+ */
+suspend fun SnackbarHostState.showQuickSnackbar(
+    message: String,
+    actionLabel: String? = null,
+    durationMs: Long = 2000L
+) {
+    withTimeoutOrNull(durationMs) {
+        showSnackbar(
+            message = message,
+            actionLabel = actionLabel,
+            duration = SnackbarDuration.Short
+        )
+    }
+}

--- a/app/src/main/java/com/raylabs/laundryhub/ui/component/SectionOrLoading.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/component/SectionOrLoading.kt
@@ -22,6 +22,7 @@ fun SectionOrLoading(
     isLoading: Boolean,
     error: String?,
     hasContent: Boolean = false,
+    showMiniLoading: Boolean = true,
     content: @Composable () -> Unit
 ) {
     when {
@@ -51,7 +52,7 @@ fun SectionOrLoading(
             Column(modifier = Modifier.fillMaxWidth()) {
                 Box(modifier = Modifier.fillMaxWidth()) {
                     content()
-                    if (isLoading) {
+                    if (isLoading && showMiniLoading) {
                         Box(
                             modifier = Modifier
                                 .align(Alignment.TopEnd)

--- a/app/src/main/java/com/raylabs/laundryhub/ui/history/HistoryScreenView.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/history/HistoryScreenView.kt
@@ -70,7 +70,7 @@ fun HistoryScreenView(
                 modifier = Modifier.fillMaxSize(),
                 isRefreshing = state.history.isLoading,
                 onRefresh = { viewModel.refreshHistory() },
-                onEntryClick = { selectedEntry = it }
+                onEntryClick = { selectedEntry = it }, onEntryDelete = { pendingDeleteEntry = it }
             )
 
             TransactionEntryActionSheet(
@@ -134,7 +134,7 @@ fun HistoryContent(
     modifier: Modifier,
     isRefreshing: Boolean = false,
     onRefresh: () -> Unit = {},
-    onEntryClick: (EntryItem) -> Unit = {}
+    onEntryClick: (EntryItem) -> Unit = {}, onEntryDelete: (EntryItem) -> Unit = {}
 ) {
     val pullRefreshState = rememberPullRefreshState(
         refreshing = isRefreshing,

--- a/app/src/main/java/com/raylabs/laundryhub/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/history/HistoryViewModel.kt
@@ -27,12 +27,21 @@ class HistoryViewModel @Inject constructor(
     val uiState: HistoryUiState get() = _uiState.value
 
     init {
-        refreshHistory()
+        refreshHistory(isManual = false)
     }
 
-    fun refreshHistory() {
+    fun refreshHistory(isManual: Boolean = true) {
+        if (isManual) {
+            _uiState.value = _uiState.value.copy(isRefreshing = true)
+        }
         viewModelScope.launch {
-            loadHistory()
+            try {
+                loadHistory()
+            } finally {
+                if (isManual) {
+                    _uiState.value = _uiState.value.copy(isRefreshing = false)
+                }
+            }
         }
     }
 
@@ -47,10 +56,15 @@ class HistoryViewModel @Inject constructor(
 
         when (val result = deleteOrderUseCase(orderId = orderId)) {
             is Resource.Success -> {
+                val currentHistory = _uiState.value.history.data.orEmpty()
+                val updatedHistory = currentHistory.filterNot { item ->
+                    item is com.raylabs.laundryhub.ui.outcome.state.DateListItemUI.Entry && item.item.id == orderId
+                }
+
                 _uiState.value = _uiState.value.copy(
-                    deleteOrder = _uiState.value.deleteOrder.success(result.data)
+                    deleteOrder = _uiState.value.deleteOrder.success(result.data),
+                    history = _uiState.value.history.copy(data = updatedHistory)
                 )
-                loadHistory()
                 onComplete()
             }
 

--- a/app/src/main/java/com/raylabs/laundryhub/ui/history/state/HistoryUiState.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/history/state/HistoryUiState.kt
@@ -5,5 +5,6 @@ import com.raylabs.laundryhub.ui.outcome.state.DateListItemUI
 
 data class HistoryUiState(
     val history: SectionState<List<DateListItemUI>> = SectionState(),
-    val deleteOrder: SectionState<Boolean> = SectionState()
+    val deleteOrder: SectionState<Boolean> = SectionState(),
+    val isRefreshing: Boolean = false
 )

--- a/app/src/main/java/com/raylabs/laundryhub/ui/home/HomeScreenView.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/home/HomeScreenView.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.raylabs.laundryhub.R
 import com.raylabs.laundryhub.ui.common.dummy.home.dummyState
+import com.raylabs.laundryhub.ui.common.util.showQuickSnackbar
 import com.raylabs.laundryhub.ui.component.GreetingWithImageBackground
 import com.raylabs.laundryhub.ui.component.InfoCard
 import com.raylabs.laundryhub.ui.component.InlineAdaptiveBannerAd
@@ -136,7 +137,7 @@ fun HomeScreenContent(
 
     LaunchedEffect(state.orderUpdateKey, state.user.errorMessage, state.todayIncome.errorMessage, state.summary.errorMessage, state.gross.errorMessage, state.unpaidOrder.errorMessage) {
         listOf(state.user, state.todayIncome, state.summary, state.gross, state.unpaidOrder).forEach {
-            it.errorMessage?.let { msg -> snackBarHostState.showSnackbar(msg) }
+            it.errorMessage?.let { msg -> snackBarHostState.showQuickSnackbar(msg) }
         }
     }
 
@@ -162,6 +163,7 @@ fun HomeScreenContent(
                         isLoading = state.summary.isLoading,
                         error = state.summary.errorMessage,
                         hasContent = !state.summary.data.isNullOrEmpty(),
+                        showMiniLoading = !state.isRefreshing,
                         content = {
                             InfoCardSection(
                                 summary = state.summary.data.orEmpty(),
@@ -194,6 +196,7 @@ fun HomeScreenContent(
                     isLoading = state.todayIncome.isLoading,
                     error = state.todayIncome.errorMessage,
                     hasContent = !state.todayIncome.data.isNullOrEmpty(),
+                    showMiniLoading = !state.isRefreshing,
                     content = {
                         val list = state.todayIncome.data.orEmpty()
                         if (list.isEmpty()) {

--- a/app/src/main/java/com/raylabs/laundryhub/ui/outcome/OutcomeScreenView.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/outcome/OutcomeScreenView.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.raylabs.laundryhub.R
 import com.raylabs.laundryhub.ui.common.util.SectionState
+import com.raylabs.laundryhub.ui.common.util.showQuickSnackbar
 import com.raylabs.laundryhub.ui.component.DateHeader
 import com.raylabs.laundryhub.ui.component.DefaultTopAppBar
 import com.raylabs.laundryhub.ui.component.EntryItemCard
@@ -95,7 +96,7 @@ fun OutcomeScreenView(
                     val outcomeData = viewModel.buildOutcomeDataForSubmit()
                     if (outcomeData == null) {
                         coroutineScope.launch {
-                            scaffoldState.snackbarHostState.showSnackbar(
+                            scaffoldState.snackbarHostState.showQuickSnackbar(
                                 context.getString(R.string.outcome_id_unavailable)
                             )
                         }
@@ -106,7 +107,7 @@ fun OutcomeScreenView(
                         viewModel.submitOutcome(outcomeData) {
                             hideSheet()
                             onOutcomeChanged()
-                            scaffoldState.snackbarHostState.showSnackbar(
+                            scaffoldState.snackbarHostState.showQuickSnackbar(
                                 context.getString(R.string.outcome_submit_success, outcomeData.id)
                             )
                         }
@@ -116,7 +117,7 @@ fun OutcomeScreenView(
                     val outcomeData = viewModel.buildOutcomeDataForUpdate()
                     if (outcomeData == null) {
                         coroutineScope.launch {
-                            scaffoldState.snackbarHostState.showSnackbar(
+                            scaffoldState.snackbarHostState.showQuickSnackbar(
                                 context.getString(R.string.outcome_id_unavailable)
                             )
                         }
@@ -127,7 +128,7 @@ fun OutcomeScreenView(
                         viewModel.updateOutcome(outcomeData) {
                             hideSheet()
                             onOutcomeChanged()
-                            scaffoldState.snackbarHostState.showSnackbar(
+                            scaffoldState.snackbarHostState.showQuickSnackbar(
                                 context.getString(R.string.outcome_update_success, outcomeData.id)
                             )
                         }
@@ -164,7 +165,7 @@ fun OutcomeScreenView(
                     bannerState = resolvedBannerState,
                     scaffoldState = scaffoldState,
                     modifier = Modifier.fillMaxSize(),
-                    isRefreshing = state.outcome.isLoading,
+                    isRefreshing = state.isRefreshing,
                     onRefresh = { viewModel.refreshOutcomeList() },
                     onEntryClick = { entry ->
                         selectedEntry = entry
@@ -183,7 +184,7 @@ fun OutcomeScreenView(
                                 bottomSheetState.show()
                             } else {
                                 viewModel.uiState.editOutcome.errorMessage?.let { message ->
-                                    scaffoldState.snackbarHostState.showSnackbar(message)
+                                    scaffoldState.snackbarHostState.showQuickSnackbar(message)
                                 }
                             }
                         }
@@ -207,12 +208,12 @@ fun OutcomeScreenView(
                                 onComplete = {
                                     pendingDeleteEntry = null
                                     onOutcomeChanged()
-                                    scaffoldState.snackbarHostState.showSnackbar(
+                                    scaffoldState.snackbarHostState.showQuickSnackbar(
                                         context.getString(R.string.outcome_delete_success, entry.id)
                                     )
                                 },
                                 onError = { message ->
-                                    scaffoldState.snackbarHostState.showSnackbar(
+                                    scaffoldState.snackbarHostState.showQuickSnackbar(
                                         message.ifBlank {
                                             context.getString(R.string.outcome_delete_failed)
                                         }
@@ -245,7 +246,7 @@ fun OutcomeContent(
 ) {
     LaunchedEffect(state.outcome.errorMessage) {
         state.outcome.errorMessage?.let { msg ->
-            scaffoldState.snackbarHostState.showSnackbar(msg)
+            scaffoldState.snackbarHostState.showQuickSnackbar(msg)
         }
     }
 
@@ -263,6 +264,7 @@ fun OutcomeContent(
             isLoading = state.outcome.isLoading,
             error = state.outcome.errorMessage,
             hasContent = !state.outcome.data.isNullOrEmpty(),
+            showMiniLoading = false,
             content = {
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
                     item(key = "outcome_inline_banner") {

--- a/app/src/main/java/com/raylabs/laundryhub/ui/outcome/OutcomeViewModel.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/outcome/OutcomeViewModel.kt
@@ -38,13 +38,22 @@ class OutcomeViewModel @Inject constructor(
     val uiState: OutcomeUiState get() = _uiState.value
 
     init {
-        refreshOutcomeList()
+        refreshOutcomeList(isManual = false)
     }
 
-    fun refreshOutcomeList() {
+    fun refreshOutcomeList(isManual: Boolean = true) {
+        if (isManual) {
+            _uiState.value = _uiState.value.copy(isRefreshing = true)
+        }
         viewModelScope.launch {
-            loadOutcomeList()
-            loadLastOutcomeId()
+            try {
+                loadOutcomeList()
+                loadLastOutcomeId()
+            } finally {
+                if (isManual) {
+                    _uiState.value = _uiState.value.copy(isRefreshing = false)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/raylabs/laundryhub/ui/outcome/state/OutcomeUiState.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/outcome/state/OutcomeUiState.kt
@@ -28,6 +28,7 @@ data class OutcomeUiState(
     //flag
     val isSubmitting: Boolean = false,
     val isEditMode: Boolean = false,
+    val isRefreshing: Boolean = false
 )
 
 val OutcomeUiState.isSubmitEnabled: Boolean

--- a/app/src/main/java/com/raylabs/laundryhub/ui/profile/inventory/InventoryScreenView.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/profile/inventory/InventoryScreenView.kt
@@ -48,6 +48,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.raylabs.laundryhub.R
 import com.raylabs.laundryhub.core.domain.model.sheets.PackageData
 import com.raylabs.laundryhub.ui.common.dummy.inventory.dummyInventoryUiState
+import com.raylabs.laundryhub.ui.common.util.showQuickSnackbar
 import com.raylabs.laundryhub.ui.component.DefaultTopAppBar
 import com.raylabs.laundryhub.ui.component.InlineAdaptiveBannerAd
 import com.raylabs.laundryhub.ui.component.InlineAdaptiveBannerAdState
@@ -86,7 +87,7 @@ fun InventoryScreenView(
         listOfNotNull(state.packages.errorMessage, state.otherPackages.errorMessage)
             .firstOrNull()
             ?.let { message ->
-                scaffoldState.snackbarHostState.showSnackbar(message)
+                scaffoldState.snackbarHostState.showQuickSnackbar(message)
             }
     }
 
@@ -149,7 +150,7 @@ fun InventoryScreenView(
                             sheetRowIndex = item.sheetRowIndex,
                             onComplete = {
                                 pendingDeletePackage = null
-                                scaffoldState.snackbarHostState.showSnackbar(
+                                scaffoldState.snackbarHostState.showQuickSnackbar(
                                     context.getString(
                                         R.string.inventory_package_delete_success,
                                         item.name
@@ -157,7 +158,7 @@ fun InventoryScreenView(
                                 )
                             },
                             onError = { message ->
-                                scaffoldState.snackbarHostState.showSnackbar(
+                                scaffoldState.snackbarHostState.showQuickSnackbar(
                                     message.ifBlank {
                                         context.getString(R.string.inventory_package_delete_failed)
                                     }
@@ -207,7 +208,7 @@ fun InventoryScreenView(
                                 packageData = draft.toPackageData(),
                                 onComplete = {
                                     packageEditorState = null
-                                    scaffoldState.snackbarHostState.showSnackbar(
+                                    scaffoldState.snackbarHostState.showQuickSnackbar(
                                         context.getString(
                                             R.string.inventory_package_update_success,
                                             draft.name.trim()
@@ -215,7 +216,7 @@ fun InventoryScreenView(
                                     )
                                 },
                                 onError = { message ->
-                                    scaffoldState.snackbarHostState.showSnackbar(
+                                    scaffoldState.snackbarHostState.showQuickSnackbar(
                                         message.ifBlank {
                                             context.getString(R.string.inventory_package_update_failed)
                                         }
@@ -227,7 +228,7 @@ fun InventoryScreenView(
                                 packageData = draft.toPackageData(),
                                 onComplete = {
                                     packageEditorState = null
-                                    scaffoldState.snackbarHostState.showSnackbar(
+                                    scaffoldState.snackbarHostState.showQuickSnackbar(
                                         context.getString(
                                             R.string.inventory_package_add_success,
                                             draft.name.trim()
@@ -235,7 +236,7 @@ fun InventoryScreenView(
                                     )
                                 },
                                 onError = { message ->
-                                    scaffoldState.snackbarHostState.showSnackbar(
+                                    scaffoldState.snackbarHostState.showQuickSnackbar(
                                         message.ifBlank {
                                             context.getString(R.string.inventory_package_add_failed)
                                         }
@@ -282,6 +283,7 @@ fun InventoryContent(
                     isLoading = state.packages.isLoading,
                     error = state.packages.errorMessage,
                     hasContent = !state.packages.data.isNullOrEmpty(),
+                    showMiniLoading = false,
                     content = {
                         SetupPackageSection(
                             packages = state.packages.data.orEmpty(),
@@ -302,6 +304,7 @@ fun InventoryContent(
                     isLoading = state.otherPackages.isLoading,
                     error = state.otherPackages.errorMessage,
                     hasContent = !state.otherPackages.data.isNullOrEmpty(),
+                    showMiniLoading = false,
                     content = {
                         OtherPackagesSection(
                             data = state.otherPackages.data.orEmpty(),

--- a/docs/core/performance/README.md
+++ b/docs/core/performance/README.md
@@ -314,6 +314,36 @@ Benchmark verifier note:
 - if the search field does not appear after the search button is tapped, the benchmark now falls back to scanning for `Order #<id>`
 - this keeps the benchmark focused on the real product result instead of failing on one brittle UIAutomator interaction
 
+## Post-Delete UI Optimization
+
+The delete-order flow was optimized to avoid redundant network overhead.
+
+What changed:
+
+- `HistoryViewModel.deleteOrder()` now uses **Local State Mutation**.
+- Instead of calling `loadHistory()` (which re-downloads the entire list from Google Sheets), the app now filters out the deleted item from the local `HistoryUiState` in memory immediately after a successful API response.
+- This removes one full sequential network fetch from the user's wait time.
+
+Latest real-device Macrobenchmark for Delete Flow:
+
+- captured at: `2026-04-26 14:42 WIB`
+- device: `SM_S931B` (via 192.168.1.65:36043)
+- Android: `16`
+- build: `benchmark`
+- scenario: `Home -> History -> Tap Order -> Delete -> Success Snackbar`
+
+Delete flow comparison:
+
+| Metric | Before optimization | After optimization | Delta | Interpretation |
+| --- | --- | --- | --- | --- |
+| `open_history_ms_median` | `537` | `607` | `+70 ms` | normal UI noise |
+| `delete_to_success_ms_median` | `2434` | `1716` | `-718 ms` | **Major win**; removed redundant list fetch |
+| `total_flow_ms_median` | `5540` | `4871` | `-669 ms` | meaningful end-to-end improvement |
+
+New benchmark file:
+
+- `macrobenchmark/src/main/java/com/raylabs/laundryhub/macrobenchmark/DeleteOrderFlowBenchmark.kt`
+
 ## Local JVM Baselines
 
 There are now two local, no-device baseline tests that can be run through normal JVM unit tests.
@@ -385,3 +415,4 @@ Latest successful verification:
 - `adb install -r macrobenchmark/build/outputs/apk/benchmark/macrobenchmark-benchmark.apk`
 - `adb devices -l`
 - `adb shell am instrument -w -e class com.raylabs.laundryhub.macrobenchmark.AddOrderFlowBenchmark com.raylabs.laundryhub.macrobenchmark/androidx.test.runner.AndroidJUnitRunner`
+- `adb shell am instrument -w -e class com.raylabs.laundryhub.macrobenchmark.DeleteOrderFlowBenchmark com.raylabs.laundryhub.macrobenchmark/androidx.test.runner.AndroidJUnitRunner`

--- a/macrobenchmark/src/main/java/com/raylabs/laundryhub/macrobenchmark/DeleteOrderFlowBenchmark.kt
+++ b/macrobenchmark/src/main/java/com/raylabs/laundryhub/macrobenchmark/DeleteOrderFlowBenchmark.kt
@@ -1,0 +1,659 @@
+package com.raylabs.laundryhub.macrobenchmark
+
+import android.os.SystemClock
+import android.util.Log
+import androidx.benchmark.macro.BaselineProfileMode
+import androidx.benchmark.macro.CompilationMode
+import androidx.benchmark.macro.FrameTimingMetric
+import androidx.benchmark.macro.MacrobenchmarkScope
+import androidx.benchmark.macro.junit4.MacrobenchmarkRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.BySelector
+import androidx.test.uiautomator.UiObject2
+import androidx.test.uiautomator.Until
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class DeleteOrderFlowBenchmark {
+
+    @get:Rule
+    val benchmarkRule = MacrobenchmarkRule()
+
+    @Test
+    fun deleteOrderFlow_updatesHistory() {
+        val openHistoryDurations = mutableListOf<Long>()
+        val deleteToSuccessDurations = mutableListOf<Long>()
+        val totalFlowDurations = mutableListOf<Long>()
+        var iteration = 0
+
+        var orderNameForDeletion = ""
+        var orderIdForDeletion = ""
+
+        benchmarkRule.measureRepeated(
+            packageName = TARGET_PACKAGE,
+            metrics = listOf(FrameTimingMetric()),
+            compilationMode = CompilationMode.Partial(
+                baselineProfileMode = BaselineProfileMode.Disable,
+                warmupIterations = 1
+            ),
+            iterations = 1,
+            setupBlock = {
+                pressHome()
+                launchAppFromShell()
+                ensureHomeReady()
+
+                // Create a new order to be deleted
+                orderNameForDeletion = "delbench${SystemClock.elapsedRealtime() % 100000}"
+                openOrderSheet()
+                selectFirstPackage()
+                fillRequiredFields(orderName = orderNameForDeletion, price = ORDER_PRICE)
+                tapObjectCenter(
+                    selector = By.desc(ORDER_SUBMIT_BUTTON_DESCRIPTION),
+                    debugLabel = ORDER_SUBMIT_BUTTON_DESCRIPTION,
+                    timeoutMs = FORM_READY_TIMEOUT_MS
+                )
+                val successMessage = waitForObject(
+                    By.textContains(ORDER_SUBMIT_SUCCESS_TEXT),
+                    SUBMIT_TIMEOUT_MS
+                ).text.orEmpty()
+                orderIdForDeletion = extractSubmittedOrderId(successMessage)
+                
+                // Allow the UI to settle after the toast
+                device.waitForIdle()
+                SystemClock.sleep(2000)
+            }
+        ) {
+            iteration += 1
+            val totalStart = SystemClock.elapsedRealtime()
+
+            // 1. Open History Tab
+            val historyStart = SystemClock.elapsedRealtime()
+            tapObjectCenter(
+                selector = By.desc(HISTORY_NAV_DESCRIPTION),
+                debugLabel = HISTORY_NAV_DESCRIPTION,
+                timeoutMs = HOME_LOAD_TIMEOUT_MS
+            )
+            // Wait for history to load (either order item or empty state)
+            waitForAnyObject(
+                selectors = listOf(
+                    By.textStartsWith(ORDER_LABEL_PREFIX),
+                    By.text(NO_DATA_TEXT)
+                ),
+                timeoutMs = HISTORY_LOAD_TIMEOUT_MS
+            )
+            val openHistoryMs = SystemClock.elapsedRealtime() - historyStart
+
+            // 2. Find and Tap the order we just created
+            val orderSelector = By.textStartsWith("Order #$orderIdForDeletion")
+            
+            // Just wait for it to appear, since it's the newest order it should be at the top
+            waitForObject(orderSelector, HISTORY_LOAD_TIMEOUT_MS)
+            
+            // Retry click if sheet doesn't appear
+            var actionSheetVisible = false
+            repeat(3) { attempt ->
+                val currentCard = device.findObject(orderSelector)
+                if (currentCard != null) {
+                    val bounds = currentCard.visibleBounds
+                    if (!bounds.isEmpty) {
+                        device.click(bounds.centerX(), bounds.centerY())
+                        device.waitForIdle()
+                    }
+                }
+                
+                if (device.hasObject(By.textContains(DELETE_ORDER_ACTION_TEXT))) {
+                    actionSheetVisible = true
+                    return@repeat
+                }
+                SystemClock.sleep(1500)
+            }
+            
+            check(actionSheetVisible) {
+                "Action sheet with '$DELETE_ORDER_ACTION_TEXT' did not appear after clicking card $orderIdForDeletion"
+            }
+
+            // 3. Open Action Sheet -> Tap Delete
+            tapObjectCenter(
+                selector = By.textContains(DELETE_ORDER_ACTION_TEXT),
+                debugLabel = "Delete order action",
+                timeoutMs = SHORT_WAIT_TIMEOUT_MS
+            )
+
+            // 4. Open Confirmation Sheet -> Tap Delete
+            tapObjectCenter(
+                selector = By.text(DELETE_CONFIRM_TEXT),
+                debugLabel = "Delete confirm button",
+                timeoutMs = SHORT_WAIT_TIMEOUT_MS
+            )
+
+            // 5. Wait for Delete Success
+            val deleteStart = SystemClock.elapsedRealtime()
+            waitForObject(
+                By.textContains(ORDER_DELETE_SUCCESS_TEXT),
+                DELETE_TIMEOUT_MS
+            )
+            val deleteToSuccessMs = SystemClock.elapsedRealtime() - deleteStart
+            
+            val totalFlowMs = SystemClock.elapsedRealtime() - totalStart
+
+            openHistoryDurations += openHistoryMs
+            deleteToSuccessDurations += deleteToSuccessMs
+            totalFlowDurations += totalFlowMs
+
+            Log.i(
+                LOG_TAG,
+                "BENCHMARK_ITERATION iteration=$iteration " +
+                    "open_history_ms=$openHistoryMs " +
+                    "delete_to_success_ms=$deleteToSuccessMs " +
+                    "total_flow_ms=$totalFlowMs " +
+                    "order_name=$orderNameForDeletion " +
+                    "order_id=$orderIdForDeletion"
+            )
+        }
+
+        Log.i(
+            LOG_TAG,
+            "BENCHMARK_SUMMARY " +
+                "open_history_ms_median=${openHistoryDurations.median()} " +
+                "delete_to_success_ms_median=${deleteToSuccessDurations.median()} " +
+                "total_flow_ms_median=${totalFlowDurations.median()}"
+        )
+    }
+
+    private fun MacrobenchmarkScope.openOrderSheet(): Long {
+        val start = SystemClock.elapsedRealtime()
+        tapObjectCenter(
+            selector = By.desc(ORDER_NAV_DESCRIPTION),
+            debugLabel = ORDER_NAV_DESCRIPTION,
+            timeoutMs = HOME_LOAD_TIMEOUT_MS
+        )
+        waitForObject(By.desc(ORDER_SHEET_DESCRIPTION), SHEET_LOAD_TIMEOUT_MS)
+        return SystemClock.elapsedRealtime() - start
+    }
+
+    private fun MacrobenchmarkScope.launchAppFromShell() {
+        device.executeShellCommand(
+            "am start -W -a android.intent.action.MAIN " +
+                "-c android.intent.category.LAUNCHER " +
+                "$TARGET_PACKAGE/.ui.MainActivity"
+        )
+        device.waitForIdle()
+    }
+
+    private fun MacrobenchmarkScope.ensureHomeReady() {
+        when (waitForStartupState()) {
+            StartupState.HOME -> return
+
+            StartupState.SPREADSHEET_SETUP -> {
+                Log.i(LOG_TAG, "Spreadsheet setup screen detected before benchmark flow")
+
+                val connectSheetsButton = waitForOptionalObject(
+                    By.text(CONNECT_GOOGLE_SHEETS_TEXT),
+                    SHORT_WAIT_TIMEOUT_MS
+                )
+                check(connectSheetsButton == null) {
+                    "Benchmark device still needs Google Sheets access. Open the app once and grant Sheets access before rerunning Macrobenchmark."
+                }
+
+                val validateButton = waitForOptionalObject(
+                    By.text(VALIDATE_AND_CONTINUE_TEXT),
+                    SHORT_WAIT_TIMEOUT_MS
+                )
+                if (validateButton != null && validateButton.isEnabled) {
+                    validateButton.click()
+                    device.waitForIdle()
+                }
+
+                waitForHomeReady()
+            }
+
+            StartupState.ONBOARDING -> error(
+                "Benchmark app reached onboarding. Sign in once on this benchmark build/device before rerunning Macrobenchmark."
+            )
+
+            StartupState.UNKNOWN -> {
+                val windowHierarchy = dumpWindowHierarchy()
+                error(
+                    "App did not reach Home, Spreadsheet Setup, or onboarding. " +
+                        "Window markers=${summarizeWindowMarkers(windowHierarchy)}"
+                )
+            }
+        }
+    }
+
+    private fun MacrobenchmarkScope.waitForStartupState(): StartupState {
+        val deadline = SystemClock.elapsedRealtime() + STARTUP_STATE_TIMEOUT_MS
+        var lastObservedState = StartupState.UNKNOWN
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (isHomeVisible()) {
+                return StartupState.HOME
+            }
+            if (device.hasObject(By.text(SPREADSHEET_SETUP_TITLE))) {
+                lastObservedState = StartupState.SPREADSHEET_SETUP
+            }
+            if (device.hasObject(By.text(LOGIN_WITH_GOOGLE_TEXT))) {
+                lastObservedState = StartupState.ONBOARDING
+            }
+
+            device.waitForIdle()
+            SystemClock.sleep(500)
+        }
+
+        return lastObservedState
+    }
+
+    private fun MacrobenchmarkScope.dumpWindowHierarchy(): String {
+        return device.executeShellCommand(
+            "uiautomator dump /sdcard/laundryhub-benchmark-window.xml >/dev/null; " +
+                "cat /sdcard/laundryhub-benchmark-window.xml"
+        )
+    }
+
+    private fun summarizeWindowMarkers(windowHierarchy: String): String {
+        val markers = buildList {
+            if (windowHierarchy.contains(TODAY_ACTIVITY_TITLE) || windowHierarchy.contains(PENDING_ORDERS_TITLE)) {
+                add("home")
+            }
+            if (windowHierarchy.contains("content-desc=\"$ORDER_NAV_DESCRIPTION\"")) {
+                add("app_shell")
+            }
+            if (windowHierarchy.contains(SPREADSHEET_SETUP_TITLE)) add("spreadsheet_setup")
+            if (windowHierarchy.contains(LOGIN_WITH_GOOGLE_TEXT)) add("onboarding")
+            if (windowHierarchy.contains(VALIDATE_AND_CONTINUE_TEXT)) add("validate_button")
+            if (windowHierarchy.contains(CONNECT_GOOGLE_SHEETS_TEXT)) add("connect_sheets")
+        }
+        return if (markers.isEmpty()) "none" else markers.joinToString()
+    }
+
+    private fun MacrobenchmarkScope.waitForHomeReady() {
+        val deadline = SystemClock.elapsedRealtime() + HOME_LOAD_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (isHomeVisible()) return
+            device.waitForIdle()
+            SystemClock.sleep(250)
+        }
+
+        error("Timed out waiting for Home markers to become visible")
+    }
+
+    private fun MacrobenchmarkScope.isHomeVisible(): Boolean {
+        return device.hasObject(By.text(TODAY_ACTIVITY_TITLE)) ||
+            device.hasObject(By.text(PENDING_ORDERS_TITLE)) ||
+            device.hasObject(By.desc(ORDER_NAV_DESCRIPTION))
+    }
+
+    private fun MacrobenchmarkScope.fillRequiredFields(orderName: String, price: String) {
+        focusFieldAndInputText(
+            selectors = listOf(
+                By.desc(ORDER_NAME_FIELD_DESCRIPTION),
+                By.text(NAME_LABEL)
+            ),
+            value = orderName,
+            debugLabel = ORDER_NAME_FIELD_DESCRIPTION
+        )
+        device.pressBack()
+        device.waitForIdle()
+        SystemClock.sleep(300)
+        ensureFieldVisible(
+            selectors = listOf(
+                By.desc(ORDER_PRICE_FIELD_DESCRIPTION),
+                By.text(PRICE_LABEL)
+            ),
+            debugLabel = ORDER_PRICE_FIELD_DESCRIPTION
+        )
+        focusFieldAndInputText(
+            selectors = listOf(
+                By.desc(ORDER_PRICE_FIELD_DESCRIPTION),
+                By.text(PRICE_LABEL)
+            ),
+            value = price,
+            debugLabel = ORDER_PRICE_FIELD_DESCRIPTION
+        )
+        device.pressBack()
+        device.waitForIdle()
+    }
+
+    private fun MacrobenchmarkScope.selectFirstPackage() {
+        tapObjectCenter(
+            selector = firstPackageSelector(),
+            debugLabel = "first package option",
+            timeoutMs = FORM_READY_TIMEOUT_MS
+        )
+        device.waitForIdle()
+    }
+
+    private fun MacrobenchmarkScope.tapObjectCenter(
+        selector: BySelector,
+        debugLabel: String,
+        timeoutMs: Long
+    ) {
+        val current = waitForObject(selector, timeoutMs)
+        val bounds = current.visibleBounds
+        check(device.click(bounds.centerX(), bounds.centerY())) {
+            "Failed to tap object center for $debugLabel at $bounds"
+        }
+        device.waitForIdle()
+    }
+
+    private fun MacrobenchmarkScope.focusFieldAndInputText(
+        selectors: List<BySelector>,
+        value: String,
+        debugLabel: String
+    ) {
+        val field = waitForAnyObject(selectors, FORM_READY_TIMEOUT_MS)
+        inputTextIntoObject(field, value, debugLabel)
+    }
+
+    private fun MacrobenchmarkScope.inputTextIntoObject(
+        field: UiObject2,
+        value: String,
+        debugLabel: String
+    ) {
+        val bounds = field.visibleBounds
+        check(device.click(bounds.centerX(), bounds.centerY())) {
+            "Failed to tap field for $debugLabel at $bounds"
+        }
+        device.executeShellCommand("input text ${escapeForShellInput(value)}")
+        device.waitForIdle()
+        SystemClock.sleep(300)
+    }
+
+    private fun MacrobenchmarkScope.ensureFieldVisible(
+        selectors: List<BySelector>,
+        debugLabel: String
+    ) {
+        val deadline = SystemClock.elapsedRealtime() + FORM_READY_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val field = waitForOptionalAnyObject(selectors, SHORT_WAIT_TIMEOUT_MS)
+            if (field != null && !field.visibleBounds.isEmpty) {
+                return
+            }
+
+            device.swipe(
+                (device.displayWidth * 0.88f).toInt(),
+                (device.displayHeight * 0.82f).toInt(),
+                (device.displayWidth * 0.88f).toInt(),
+                (device.displayHeight * 0.42f).toInt(),
+                24
+            )
+            device.waitForIdle()
+            SystemClock.sleep(400)
+        }
+
+        error("Timed out waiting for field to become visible: $debugLabel")
+    }
+
+    private fun MacrobenchmarkScope.waitForPendingOrderVisibility(
+        orderId: String,
+        orderName: String
+    ) {
+        ensurePendingOrdersVisible()
+
+        if (filterPendingOrdersByName(orderName)) {
+            val displayName = orderName.replaceFirstChar { firstChar ->
+                firstChar.uppercase()
+            }
+            waitForSingleFilteredPendingResult(displayName)
+            return
+        }
+
+        waitForPendingOrderLabel(orderId)
+    }
+
+    private fun MacrobenchmarkScope.filterPendingOrdersByName(orderName: String): Boolean {
+        if (!openPendingOrderSearch()) {
+            return false
+        }
+
+        val searchField = waitForOptionalAnyObject(
+            selectors = listOf(
+                By.desc(PENDING_ORDER_SEARCH_FIELD_DESCRIPTION),
+                By.clazz("android.widget.EditText"),
+                By.text(SEARCH_CUSTOMER_PLACEHOLDER)
+            ),
+            timeoutMs = SHORT_WAIT_TIMEOUT_MS
+        )
+        if (searchField == null || searchField.visibleBounds.isEmpty) {
+            Log.i(LOG_TAG, "Pending search field did not appear; falling back to order id scan")
+            device.pressBack()
+            device.waitForIdle()
+            return false
+        }
+
+        inputTextIntoObject(
+            field = searchField,
+            value = orderName,
+            debugLabel = PENDING_ORDER_SEARCH_LABEL
+        )
+        device.pressBack()
+        device.waitForIdle()
+        return true
+    }
+
+    private fun MacrobenchmarkScope.waitForPendingOrderLabel(orderId: String) {
+        val orderLabel = "Order #$orderId"
+        val deadline = SystemClock.elapsedRealtime() + PENDING_UPDATE_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (device.hasObject(By.text(orderLabel))) {
+                return
+            }
+
+            device.swipe(
+                device.displayWidth / 2,
+                (device.displayHeight * 0.78f).toInt(),
+                device.displayWidth / 2,
+                (device.displayHeight * 0.34f).toInt(),
+                24
+            )
+            device.waitForIdle()
+            SystemClock.sleep(400)
+        }
+
+        error("Timed out waiting for pending order card to show $orderLabel")
+    }
+
+    private fun MacrobenchmarkScope.openPendingOrderSearch(): Boolean {
+        repeat(6) {
+            val searchButton = waitForOptionalObject(
+                selector = By.desc(OPEN_SEARCH_DESCRIPTION),
+                timeoutMs = SHORT_WAIT_TIMEOUT_MS
+            )
+            if (searchButton != null) {
+                val bounds = searchButton.visibleBounds
+                check(device.click(bounds.centerX(), bounds.centerY())) {
+                    "Failed to tap Pending Order search button at $bounds"
+                }
+                device.waitForIdle()
+                return true
+            }
+
+            device.swipe(
+                device.displayWidth / 2,
+                (device.displayHeight * 0.34f).toInt(),
+                device.displayWidth / 2,
+                (device.displayHeight * 0.74f).toInt(),
+                24
+            )
+            device.waitForIdle()
+            SystemClock.sleep(400)
+        }
+
+        return false
+    }
+
+    private fun MacrobenchmarkScope.waitForSingleFilteredPendingResult(displayName: String) {
+        val deadline = SystemClock.elapsedRealtime() + PENDING_UPDATE_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val visibleOrderLabels = device.findObjects(By.textStartsWith(ORDER_LABEL_PREFIX))
+                .count { !it.visibleBounds.isEmpty }
+            val hasDisplayName = device.hasObject(By.text(displayName))
+
+            if (hasDisplayName && visibleOrderLabels == 1) {
+                return
+            }
+
+            device.waitForIdle()
+            SystemClock.sleep(300)
+        }
+
+        error("Timed out waiting for exactly one filtered pending result for $displayName")
+    }
+
+    private fun MacrobenchmarkScope.ensurePendingOrdersVisible() {
+        val deadline = SystemClock.elapsedRealtime() + PENDING_UPDATE_TIMEOUT_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val hasPendingHeader = device.hasObject(By.text(PENDING_ORDERS_TITLE)) ||
+                device.hasObject(By.desc(OPEN_SEARCH_DESCRIPTION))
+            if (hasPendingHeader) {
+                return
+            }
+
+            device.swipe(
+                device.displayWidth / 2,
+                (device.displayHeight * 0.82f).toInt(),
+                device.displayWidth / 2,
+                (device.displayHeight * 0.42f).toInt(),
+                24
+            )
+            device.waitForIdle()
+            SystemClock.sleep(400)
+        }
+
+        error("Timed out waiting for Pending Orders section to become visible")
+    }
+
+    private fun MacrobenchmarkScope.waitForObject(
+        selector: BySelector,
+        timeoutMs: Long
+    ): UiObject2 {
+        device.wait(Until.hasObject(selector), timeoutMs)
+        return requireNotNull(device.findObject(selector)) {
+            "Timed out waiting for UI object: $selector"
+        }
+    }
+
+    private fun MacrobenchmarkScope.waitForOptionalObject(
+        selector: BySelector,
+        timeoutMs: Long
+    ): UiObject2? {
+        device.wait(Until.hasObject(selector), timeoutMs)
+        return device.findObject(selector)
+    }
+
+    private fun MacrobenchmarkScope.waitForAnyObject(
+        selectors: List<BySelector>,
+        timeoutMs: Long
+    ): UiObject2 {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            selectors.firstNotNullOfOrNull { selector -> device.findObject(selector) }?.let { return it }
+
+            device.waitForIdle()
+            SystemClock.sleep(250)
+        }
+
+        error("Timed out waiting for any UI object in selectors: $selectors")
+    }
+
+    private fun MacrobenchmarkScope.waitForOptionalAnyObject(
+        selectors: List<BySelector>,
+        timeoutMs: Long
+    ): UiObject2? {
+        val deadline = SystemClock.elapsedRealtime() + timeoutMs
+        while (SystemClock.elapsedRealtime() < deadline) {
+            selectors.firstNotNullOfOrNull { selector -> device.findObject(selector) }?.let { return it }
+
+            device.waitForIdle()
+            SystemClock.sleep(250)
+        }
+
+        return null
+    }
+
+    private fun List<Long>.median(): Long {
+        if (isEmpty()) return 0L
+        val sorted = sorted()
+        val middle = sorted.size / 2
+        return if (sorted.size % 2 == 0) {
+            (sorted[middle - 1] + sorted[middle]) / 2
+        } else {
+            sorted[middle]
+        }
+    }
+
+    companion object {
+        private const val TARGET_PACKAGE = "com.raylabs.laundryhub"
+        private const val LOG_TAG = "DeleteOrderFlowBenchmark"
+        private const val ORDER_PRICE = "8000"
+
+        private const val HISTORY_NAV_DESCRIPTION = "History"
+        private const val NO_DATA_TEXT = "No transactions today."
+        private const val DELETE_ORDER_ACTION_TEXT = "Delete order"
+        private const val DELETE_CONFIRM_TEXT = "Delete"
+        private const val ORDER_DELETE_SUCCESS_TEXT = "deleted successfully."
+        private const val HISTORY_LOAD_TIMEOUT_MS = 15_000L
+        private const val DELETE_TIMEOUT_MS = 45_000L
+
+        private const val ORDER_NAV_DESCRIPTION = "Order"
+        private const val ORDER_SHEET_DESCRIPTION = "Order sheet"
+        private const val ORDER_NAME_FIELD_DESCRIPTION = "Order name field"
+        private const val ORDER_PACKAGE_OPTION_DESCRIPTION_PREFIX = "Package option "
+        private const val ORDER_PRICE_FIELD_DESCRIPTION = "Order price field"
+        private const val ORDER_SUBMIT_BUTTON_DESCRIPTION = "Submit order"
+        private const val TODAY_ACTIVITY_TITLE = "Today Activity"
+        private const val PENDING_ORDERS_TITLE = "Pending Orders"
+        private const val ORDER_LABEL_PREFIX = "Order #"
+        private const val OPEN_SEARCH_DESCRIPTION = "Open Search"
+        private const val PENDING_ORDER_SEARCH_LABEL = "Pending order search"
+        private const val PENDING_ORDER_SEARCH_FIELD_DESCRIPTION = "Pending order search field"
+        private const val ORDER_SUBMIT_SUCCESS_TEXT = "submitted successfully."
+        private const val NAME_LABEL = "Name"
+        private const val PRICE_LABEL = "Price"
+        private const val SEARCH_CUSTOMER_PLACEHOLDER = "Search Customer"
+        private const val SPREADSHEET_SETUP_TITLE = "Set Up Your Spreadsheet"
+        private const val VALIDATE_AND_CONTINUE_TEXT = "Validate & Continue"
+        private const val CONNECT_GOOGLE_SHEETS_TEXT = "Connect Google Sheets"
+        private const val LOGIN_WITH_GOOGLE_TEXT = "Login with Google"
+
+        private const val HOME_LOAD_TIMEOUT_MS = 15_000L
+        private const val STARTUP_STATE_TIMEOUT_MS = 30_000L
+        private const val SHEET_LOAD_TIMEOUT_MS = 10_000L
+        private const val FORM_READY_TIMEOUT_MS = 20_000L
+        private const val SUBMIT_TIMEOUT_MS = 45_000L
+        private const val PENDING_UPDATE_TIMEOUT_MS = 45_000L
+        private const val SHORT_WAIT_TIMEOUT_MS = 2_500L
+
+        private fun firstPackageSelector(): BySelector = By.descStartsWith(
+            ORDER_PACKAGE_OPTION_DESCRIPTION_PREFIX
+        )
+
+        private fun extractSubmittedOrderId(successMessage: String): String {
+            val match = Regex("""Order #(\d+)""").find(successMessage)
+            return requireNotNull(match?.groupValues?.getOrNull(1)) {
+                "Unable to parse submitted order id from success message: $successMessage"
+            }
+        }
+
+        private fun escapeForShellInput(value: String): String = buildString {
+            value.forEach { char ->
+                when {
+                    char.isLetterOrDigit() -> append(char)
+                    char == ' ' -> append("%s")
+                    else -> append("\\").append(char)
+                }
+            }
+        }
+    }
+
+    private enum class StartupState {
+        HOME,
+        SPREADSHEET_SETUP,
+        ONBOARDING,
+        UNKNOWN
+    }
+}


### PR DESCRIPTION
This commit introduces a new macrobenchmark for the order deletion flow and optimizes the user experience by implementing local state mutation after deletions, reducing redundant network overhead and improving perceived performance.

### Performance & Benchmarking
- **Delete Flow Benchmark**: Added `DeleteOrderFlowBenchmark` to measure the end-to-end journey from History navigation to successful deletion.
- **Post-Delete Optimization**: Refactored `HistoryViewModel.deleteOrder()` to perform a local state mutation. Instead of re-fetching the entire list from the network after a deletion, the app now immediately filters the deleted item from the local `HistoryUiState`.
- **Latency Reduction**: Benchmark results show a ~700ms reduction in "delete to success" latency on physical devices by eliminating the sequential list refresh.
- **Documentation**: Updated `docs/core/performance/README.md` with the new benchmark methodology and comparative performance data.

### UI/UX Refinements
- **Quick Snackbars**: Introduced `showQuickSnackbar` extension for `SnackbarHostState`, defaulting to a 2-second duration for faster UI feedback compared to the standard `Long` or `Short` durations.
- **Loading States**: Enhanced `SectionOrLoading` and ViewModels (`History`, `Outcome`) to distinguish between manual pull-to-refresh and background loading. This allows for "mini-loading" indicators that don't disrupt existing content.
- **History & Outcome Screens**: Migrated all success/error notifications to the new quick snackbar utility for a snappier feel.

### Tooling & Infrastructure
- **Build Configuration**: Adjusted JVM test execution in `app/build.gradle` by reducing max heap size and increasing fork frequency to improve test runner stability.
- **State Management**: Added `isRefreshing` flags to `HistoryUiState` and `OutcomeUiState` to better manage PullRefresh states independently of initial data loading.

```kotlin
// Example of the new local state mutation logic in HistoryViewModel
is Resource.Success -> {
    val currentHistory = _uiState.value.history.data.orEmpty()
    val updatedHistory = currentHistory.filterNot { item ->
        item is DateListItemUI.Entry && item.item.id == orderId
    }

    _uiState.value = _uiState.value.copy(
        deleteOrder = _uiState.value.deleteOrder.success(result.data),
        history = _uiState.value.history.copy(data = updatedHistory)
    )
    onComplete()
}
```