### PR TITLE
docs: Add UI mirroring documentation and refine outcome submission flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ fabric.properties
 
 !/gradle/wrapper/gradle-wrapper.jar
 GEMINI.md
+DESIGN.md

--- a/app/src/main/java/com/raylabs/laundryhub/ui/outcome/OutcomeScreenView.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/outcome/OutcomeScreenView.kt
@@ -119,16 +119,14 @@ fun OutcomeScreenView(
                         onRemarkChanged = viewModel::onRemarkChanged,
                         onSubmit = {
                             val outcome = viewModel.buildOutcomeDataForSubmit()
-                            if (outcome != null) {
-                                coroutineScope.launch {
-                                    viewModel.submitOutcome(outcome) { createdOutcomeId ->
-                                        dismissSheet()
-                                        onOutcomeChanged()
-                                        scaffoldState.snackbarHostState.showSnackbar(
-                                            context.getString(R.string.outcome_submit_success, createdOutcomeId)
-                                        )
-                                        pagingItems.refresh()
-                                    }
+                            coroutineScope.launch {
+                                viewModel.submitOutcome(outcome) { createdOutcomeId ->
+                                    dismissSheet()
+                                    onOutcomeChanged()
+                                    scaffoldState.snackbarHostState.showSnackbar(
+                                        context.getString(R.string.outcome_submit_success, createdOutcomeId)
+                                    )
+                                    pagingItems.refresh()
                                 }
                             }
                         },

--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -1,0 +1,31 @@
+# LaundryHub UI Mirroring (High-Fidelity)
+
+This project provides a technical reconstruction of the LaundryHub Android UI in Stitch, derived directly from source code analysis.
+
+## Stitch Project Details
+- **Project Name:** LaundryHub Pro
+- **Project ID:** `14023573624442900648`
+- **Design System Asset:** `assets/3e4232ff7c4f4fb8a5a3d7f4be3c70ab` (Synced from `DESIGN.md`)
+
+## Accurate Screen Mapping
+| Screen Name | Stitch Screen ID | Technical Specification |
+|-------------|------------------|-------------------------|
+| Onboarding / Login | `6b654b2f440a49948a7e9eed90736fd5` | Horizontal Pager + Lottie + Login with Google button. |
+| Home Screen | `d21721e4d1cb43189ae204147dad3871` | Overlapping Header (90dp offset), Summary Grid, Pending Order Grid. |
+| Inventory Screen | `7b8da6041a0044e09a022512e7f250a8` | Package Management header, 20dp rounded cards, Suggestion chips. |
+| Transaction History | `fbe394496bd346da8dc62271e004736c` | Grouped date headers, Status badges, Rounded search bar. |
+| Profile Screen | `c700a9dfebbf4ab0971ff2d11439fa29` | Dark themed cards (#31284B / #43365F) against light background. |
+| New Order Bottom Sheet | `888a65f2b1b94e3b819c086c532f75e9` | 24px top-rounded sheet, Scrim overlay, Chip selectors. |
+
+## Key Implementation Notes (Mirroring)
+1. **Layout Logic:** The "Stacked Card" philosophy is maintained, ensuring vertical gaps and elevation match the Compose implementation.
+2. **Color Weighting:** The Profile section uses the specific "Dark Surface" tokens identified in the theme code to provide visual variety.
+3. **Hierarchy:** InfoCards on the dashboard correctly overlap the greeting header, providing the signature layered aesthetic of LaundryHub.
+4. **Form Controls:** Order entry uses specific input patterns (Horizontal scrollable cards for packages) rather than generic dropdowns.
+
+## Verification
+- [x] Code Analysis (Phase 0-2)
+- [x] DESIGN.md Specification
+- [x] Design System Lock
+- [x] High-Fidelity Generation
+- [x] Documentation Handoff

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,4 @@ org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 # org.gradle.parallel=true
 android.suppressUnsupportedCompileSdk=34,35
 kotlin.mpp.androidGradlePluginCompatibility.nowarn=true
+kotlin.mpp.applyDefaultHierarchyTemplate=false


### PR DESCRIPTION
This commit introduces comprehensive documentation for UI reconstruction and streamlines the submission logic within the outcome screen.

### Documentation
- **UI Mirroring**: Added `docs/ui/README.md` to document high-fidelity UI mirroring in Stitch. This includes technical specifications for screen mapping (Onboarding, Home, Inventory, History, Profile) and key implementation notes regarding layout logic and color weighting.
- **Project Tracking**: Included Stitch project IDs and design system asset references for cross-tool synchronization.

### UI & Logic
- **Outcome Submission**: Refactored `OutcomeScreenView.kt` to remove a redundant null check when submitting outcome data. The submission flow now triggers the coroutine directly, relying on internal `ViewModel` validation or state handling.

### Tooling & Configuration
- **Build**: Added `kotlin.mpp.applyDefaultHierarchyTemplate=false` to `gradle.properties` to provide finer control over Kotlin Multiplatform source set structures.
- **Git**: Updated `.gitignore` to exclude `DESIGN.md` and `GEMINI.md` from version control.