### PR TITLE
feat: Implement reactive sync polling and enhance summary UI stability

### DIFF
--- a/app/src/main/java/com/raylabs/laundryhub/ui/component/InfoCard.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/component/InfoCard.kt
@@ -8,11 +8,14 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontStyle
@@ -24,6 +27,7 @@ import com.raylabs.laundryhub.ui.home.state.SummaryItem
 fun InfoCard(
     summaryItem: SummaryItem,
     modifier: Modifier = Modifier,
+    isRefreshing: Boolean = false,
     onClick: (() -> Unit)? = null
 ) {
     Card(
@@ -41,12 +45,25 @@ fun InfoCard(
                 .padding(12.dp),
             verticalArrangement = Arrangement.SpaceBetween
         ) {
-            Text(
-                text = summaryItem.title,
-                style = MaterialTheme.typography.subtitle1,
-                color = summaryItem.textColor,
-                fontWeight = FontWeight.Bold
-            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = summaryItem.title,
+                    style = MaterialTheme.typography.subtitle1,
+                    color = summaryItem.textColor,
+                    fontWeight = FontWeight.Bold
+                )
+                if (isRefreshing) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        color = summaryItem.textColor,
+                        strokeWidth = 2.dp
+                    )
+                }
+            }
             Text(
                 text = summaryItem.body,
                 style = MaterialTheme.typography.body2,

--- a/app/src/main/java/com/raylabs/laundryhub/ui/home/HomeScreenView.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/home/HomeScreenView.kt
@@ -193,6 +193,7 @@ fun HomeScreenContent(
                     // Tetap tampilkan konten summary meskipun sedang refresh agar layar tidak loncat
                     InfoCardSection(
                         summary = state.summary.data.orEmpty(),
+                        isRefreshing = state.isSummaryRefreshing,
                         onGrossCardClick = onGrossCardClick,
                         modifier = Modifier
                             .fillMaxWidth()
@@ -200,9 +201,8 @@ fun HomeScreenContent(
                             .padding(horizontal = 16.dp)
                             .offset(y = 90.dp)
                     )
-                    
-                    if (state.summary.isLoading && state.summary.data.isNullOrEmpty()) {
-                        // Hanya tampilkan loading spinner jika data benar-benar kosong (first load)
+
+                    if (state.summary.isLoading && state.summary.data.isNullOrEmpty()) {                        // Hanya tampilkan loading spinner jika data benar-benar kosong (first load)
                         Box(modifier = Modifier.fillMaxWidth().height(300.dp).offset(y = 90.dp), contentAlignment = Alignment.Center) {
                             CircularProgressIndicator()
                         }
@@ -425,7 +425,7 @@ private fun ReminderDiscoveryCard(state: ReminderDiscoveryUiState, onClick: () -
 }
 
 @Composable
-fun InfoCardSection(summary: List<SummaryItem>, onGrossCardClick: () -> Unit, modifier: Modifier = Modifier) {
+fun InfoCardSection(summary: List<SummaryItem>, isRefreshing: Boolean, onGrossCardClick: () -> Unit, modifier: Modifier = Modifier) {
     LazyVerticalGrid(
         modifier = modifier,
         columns = GridCells.Fixed(2),
@@ -433,7 +433,11 @@ fun InfoCardSection(summary: List<SummaryItem>, onGrossCardClick: () -> Unit, mo
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         content = {
             items(items = summary, key = { it.title }) { mData ->
-                InfoCard(summaryItem = mData, onClick = if (mData.isInteractive) onGrossCardClick else null)
+                InfoCard(
+                    summaryItem = mData,
+                    isRefreshing = isRefreshing,
+                    onClick = if (mData.isInteractive) onGrossCardClick else null
+                )
             }
         }
     )

--- a/app/src/main/java/com/raylabs/laundryhub/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/home/HomeViewModel.kt
@@ -11,6 +11,7 @@ import com.raylabs.laundryhub.core.domain.model.sheets.GrossData
 import com.raylabs.laundryhub.core.domain.model.sheets.RangeDate
 import com.raylabs.laundryhub.core.domain.model.sheets.TransactionData
 import com.raylabs.laundryhub.core.domain.model.sheets.paidDescription
+import com.raylabs.laundryhub.core.domain.repository.LaundryRepository
 import com.raylabs.laundryhub.core.domain.usecase.reminder.EvaluateReminderCandidatesUseCase
 import com.raylabs.laundryhub.core.domain.usecase.reminder.ObserveReminderLocalStatesUseCase
 import com.raylabs.laundryhub.core.domain.usecase.reminder.ObserveReminderSettingsUseCase
@@ -20,7 +21,6 @@ import com.raylabs.laundryhub.core.domain.usecase.sheets.income.ReadIncomeTransa
 import com.raylabs.laundryhub.core.domain.usecase.user.UserUseCase
 import com.raylabs.laundryhub.shared.util.Resource
 import com.raylabs.laundryhub.ui.common.util.SectionState
-import com.raylabs.laundryhub.ui.common.util.error
 import com.raylabs.laundryhub.ui.common.util.loading
 import com.raylabs.laundryhub.ui.common.util.success
 import com.raylabs.laundryhub.ui.home.state.HomeUiState
@@ -35,6 +35,7 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -51,6 +52,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
+    private val repository: LaundryRepository,
     private val summaryUseCase: ReadSpreadsheetDataUseCase,
     private val grossUseCase: ReadGrossDataUseCase,
     private val readIncomeUseCase: ReadIncomeTransactionUseCase,
@@ -135,7 +137,7 @@ class HomeViewModel @Inject constructor(
 
             is Resource.Error -> {
                 _uiState.update {
-                    it.copy(todayIncome = it.todayIncome.error(result.message))
+                    it.copy(todayIncome = it.todayIncome.copy(isLoading = false, errorMessage = result.message))
                 }
             }
 
@@ -161,18 +163,42 @@ class HomeViewModel @Inject constructor(
         }
 
         val grossResult = grossUseCase()
-        val grossItem = if (grossResult is Resource.Success) grossResult.data.firstOrNull()?.toUi() else null
+        val currentSummaryData = _uiState.value.summary.data
+        val grossItem = if (grossResult is Resource.Success && grossResult.data.isNotEmpty()) {
+            grossResult.data.firstOrNull()?.toUi()
+        } else {
+            // Keep last known gross item from UI if fetch fails
+            currentSummaryData?.find { it.title == "Gross Income" }?.let { existingItem ->
+                // Reverse map from SummaryItem back to GrossItem is hard without full data,
+                // but we only need it for the UI construction later.
+                // We'll pass null and let `toUI` handle the missing grossItem,
+                // but wait, `toUI` creates a new list. We need a way to pass the old item.
+                null
+            }
+        }
 
         when (val result = summaryUseCase()) {
             is Resource.Success -> {
+                val newUiData = result.data.toUI(
+                    grossItem ?: currentSummaryData?.find { it.title == "Gross Income" }?.let {
+                        // Re-construct GrossItem from SummaryItem if we couldn't fetch it
+                        com.raylabs.laundryhub.ui.home.state.GrossItem(
+                            id = 0,
+                            month = "",
+                            totalNominal = it.body,
+                            orderCount = it.footer.replace(" order", "").trim(),
+                            tax = ""
+                        )
+                    }
+                )
                 _uiState.update {
-                    it.copy(summary = it.summary.success(result.data.toUI(grossItem)))
+                    it.copy(summary = it.summary.success(newUiData))
                 }
             }
 
             is Resource.Error -> {
                 _uiState.update {
-                    it.copy(summary = it.summary.error(result.message))
+                    it.copy(summary = it.summary.copy(isLoading = false, data = currentSummaryData, errorMessage = result.message))
                 }
             }
 
@@ -239,14 +265,38 @@ class HomeViewModel @Inject constructor(
 
     fun refreshAllData() {
         _uiState.update { it.copy(isRefreshing = true, refreshCounter = it.refreshCounter + 1) }
+        triggerFullReactiveSync()
+    }
+
+    private fun triggerFullReactiveSync(isSilent: Boolean = false) {
         viewModelScope.launch {
+            _uiState.update { it.copy(isSummaryRefreshing = true) }
+
+            // Trigger backend sync
+            repository.triggerManualSync()
+
+            // Poll sync status
+            var isSyncing = true
+            while (isSyncing) {
+                delay(1500)
+                val statusResult = repository.getSyncStatus()
+                if (statusResult is Resource.Success && !statusResult.data.isSyncing) {
+                    isSyncing = false
+                }
+            }
+
+            // Settlement delay
+            delay(1000)
+
+            // Final fetch
             coroutineScope {
                 listOf(
-                    async { fetchTodayIncome() },
-                    async { fetchSummary() }
+                    async { fetchTodayIncome(isSilent) },
+                    async { fetchSummary(isSilent) }
                 ).awaitAll()
             }
-            _uiState.update { it.copy(isRefreshing = false) }
+
+            _uiState.update { it.copy(isRefreshing = false, isSummaryRefreshing = false) }
         }
     }
 
@@ -283,14 +333,7 @@ class HomeViewModel @Inject constructor(
         // Silent refresh: don't clear optimistic orders immediately so they stay on screen until real data arrives
         // We also avoid setting isRefreshing = true so the pull-to-refresh spinner doesn't show
         _uiState.update { it.copy(refreshCounter = it.refreshCounter + 1) }
-        viewModelScope.launch {
-            coroutineScope {
-                listOf(
-                    async { fetchTodayIncome(isSilent = true) },
-                    async { fetchSummary(isSilent = true) }
-                ).awaitAll()
-            }
-        }
+        triggerFullReactiveSync(isSilent = true)
     }
 
     fun refreshAfterOutcomeChanged() {

--- a/app/src/main/java/com/raylabs/laundryhub/ui/home/state/HomeUiState.kt
+++ b/app/src/main/java/com/raylabs/laundryhub/ui/home/state/HomeUiState.kt
@@ -24,6 +24,7 @@ data class HomeUiState(
     val searchQuery: String = "", // Added for search functionality
     val isSearchActive: Boolean = false, // Added for search functionality
     val refreshCounter: Int = 0, // Added to trigger Paging 3 refresh
+    val isSummaryRefreshing: Boolean = false, // Added for reactive sync UI feedback
     val optimisticOrders: List<UnpaidOrderItem> = emptyList() // Added for Optimistic UI
 )
 

--- a/app/src/test/java/com/raylabs/laundryhub/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/raylabs/laundryhub/ui/home/HomeViewModelTest.kt
@@ -44,6 +44,7 @@ class HomeViewModelTest {
     private val observeReminderSettingsUseCase: ObserveReminderSettingsUseCase = mock()
     private val observeReminderLocalStatesUseCase: ObserveReminderLocalStatesUseCase = mock()
     private val evaluateReminderCandidatesUseCase: EvaluateReminderCandidatesUseCase = mock()
+    private val repository: com.raylabs.laundryhub.core.domain.repository.LaundryRepository = mock()
 
     @Before
     fun setUp() = runTest {
@@ -52,6 +53,19 @@ class HomeViewModelTest {
         whenever(observeReminderLocalStatesUseCase.invoke()).thenReturn(flowOf(emptyMap()))
         whenever(summaryUseCase.invoke(anyOrNull())).thenReturn(Resource.Success(listOf(SpreadsheetData("key", "value"))))
         whenever(grossUseCase.invoke(anyOrNull())).thenReturn(Resource.Success(emptyList()))
+        whenever(repository.getSyncStatus()).thenReturn(Resource.Success(com.raylabs.laundryhub.core.domain.model.sheets.SyncStatusResponse(
+            lastSyncTime = null,
+            changesCount = 0,
+            autoSyncIntervalMinutes = 15,
+            reverseSyncSchedule = com.raylabs.laundryhub.core.domain.model.sheets.ReverseSyncSchedule.MANUAL,
+            masterSourceOfTruth = com.raylabs.laundryhub.core.domain.model.sheets.MasterSourceOfTruth.SUPABASE,
+            isSyncing = false,
+            lastSyncStatus = "SUCCESS",
+            lastSyncError = null,
+            pendingPushCount = 0,
+            pendingDeleteCount = 0,
+            nextScheduledPushTime = null
+        )))
         
         // Also mock the parameterless calls if defaults are used
         whenever(summaryUseCase.invoke()).thenReturn(Resource.Success(listOf(SpreadsheetData("key", "value"))))
@@ -115,8 +129,41 @@ class HomeViewModelTest {
         job.cancel()
     }
 
+    @Test
+    fun `refreshAllData triggers manual sync and updates state`() = runTest {
+        val viewModel = createViewModel()
+        dispatcher.scheduler.advanceUntilIdle()
+        
+        whenever(summaryUseCase.invoke(anyOrNull())).thenReturn(Resource.Success(emptyList()))
+        whenever(grossUseCase.invoke(anyOrNull())).thenReturn(Resource.Success(emptyList()))
+        whenever(repository.getSyncStatus()).thenReturn(Resource.Success(com.raylabs.laundryhub.core.domain.model.sheets.SyncStatusResponse(
+            lastSyncTime = null,
+            changesCount = 0,
+            autoSyncIntervalMinutes = 15,
+            reverseSyncSchedule = com.raylabs.laundryhub.core.domain.model.sheets.ReverseSyncSchedule.MANUAL,
+            masterSourceOfTruth = com.raylabs.laundryhub.core.domain.model.sheets.MasterSourceOfTruth.SUPABASE,
+            isSyncing = false,
+            lastSyncStatus = "SUCCESS",
+            lastSyncError = null,
+            pendingPushCount = 0,
+            pendingDeleteCount = 0,
+            nextScheduledPushTime = null
+        )))
+        
+        viewModel.refreshAllData()
+        
+        // Wait for coroutines to execute
+        dispatcher.scheduler.advanceTimeBy(3000) // Advance past delays
+        dispatcher.scheduler.advanceUntilIdle()
+        
+        verify(repository).triggerManualSync()
+        assertEquals(false, viewModel.uiState.value.isRefreshing)
+        assertEquals(false, viewModel.uiState.value.isSummaryRefreshing)
+    }
+
     private fun createViewModel(): HomeViewModel {
         return HomeViewModel(
+            repository = repository,
             summaryUseCase = summaryUseCase,
             grossUseCase = grossUseCase,
             readIncomeUseCase = readIncomeUseCase,


### PR DESCRIPTION
This commit introduces a manual synchronization trigger and polling mechanism for the Home screen to ensure data consistency with the backend. It also improves UI stability by retaining existing data during refreshes and adding granular loading indicators to summary cards.

### Sync & State Management
- **Manual Sync Orchestration**: Introduced `triggerFullReactiveSync` in `HomeViewModel`, which triggers a backend sync via `LaundryRepository`, polls for completion, and then fetches updated income and summary data.
- **Improved Data Persistence**: Updated `fetchSummary` and `fetchTodayIncome` to retain current data in the UI state when errors occur or when a specific data point (like Gross Income) fails to fetch, preventing the UI from clearing unexpectedly.
- **Reactive UI State**: Added `isSummaryRefreshing` to `HomeUiState` to track background sync status independently from general screen loading.

### UI Components
- **Granular Loading Indicators**: Enhanced `InfoCard` to accept an `isRefreshing` parameter, displaying a small `CircularProgressIndicator` next to the title during active synchronization.
- **Layout Stability**: Modified `HomeScreenView` to pass the refresh state to `InfoCardSection` and ensured content remains visible during refreshes to avoid layout "jumping."

### Refactoring & Testing
- **Repository Integration**: Integrated `LaundryRepository` into `HomeViewModel` to facilitate sync status checks and manual triggers.
- **Unit Testing**: Added a test case in `HomeViewModelTest` to verify that `refreshAllData` correctly triggers the repository's sync logic and handles the polling lifecycle.
- **Data Mapping**: Implemented fallback logic to reconstruct `GrossItem` from existing UI state to maintain display continuity during partial data failures.